### PR TITLE
Bind keys

### DIFF
--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -312,6 +312,19 @@ impl LunaCanvas {
         self.selected_nodes.contains(&node_id)
     }
 
+    /// Select all root nodes in the canvas
+    pub fn select_all_nodes(&mut self) {
+        // Check if all nodes are already selected to avoid unnecessary work
+        if self.selected_nodes.len() == self.nodes.len() && !self.nodes.is_empty() {
+            return;
+        }
+
+        self.selected_nodes.clear();
+        self.selected_nodes
+            .extend(self.nodes.iter().map(|node| node.id()));
+        self.dirty = true;
+    }
+
     /// Update the layout for the entire canvas
     pub fn update_layout(&mut self) {
         if !self.dirty {

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -172,6 +172,10 @@ impl LunaCanvas {
                 if index == 1 {
                     node_to_select = Some(node_id);
                 }
+
+                // Make sure our next_id is higher than any loaded ID to prevent collisions
+                // NodeId stores an internal usize, so we access it with .0
+                canvas.next_id = canvas.next_id.max(node_id.0 + 1);
             }
         } else {
             // Fallback to creating a single default rectangle if CSS loading fails
@@ -180,6 +184,10 @@ impl LunaCanvas {
             rect.set_fill(Some(current_background_color));
             rect.set_border(Some(current_border_color), 1.0);
             let node_id = canvas.add_node(rect, cx);
+            
+            // Make sure our next_id is higher than the ID we just used
+            canvas.next_id = canvas.next_id.max(node_id.0 + 1);
+            
             node_to_select = Some(node_id);
         }
 
@@ -197,6 +205,7 @@ impl LunaCanvas {
     pub fn generate_id(&mut self) -> NodeId {
         let id = NodeId::new(self.next_id);
         self.next_id += 1;
+        println!("Generated new node ID: {}", id); // Debug logging
         id
     }
 

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -676,6 +676,11 @@ impl LunaCanvas {
         key_context.set("canvas", "Canvas");
         key_context
     }
+
+    pub fn deselect_all_nodes(&mut self, cx: &mut Context<Self>) {
+        self.selected_nodes.clear();
+        self.mark_dirty(cx);
+    }
 }
 
 /// Tests for AABB intersection between two bounds

--- a/src/canvas_element.rs
+++ b/src/canvas_element.rs
@@ -372,7 +372,10 @@ impl CanvasElement {
                         canvas.clear_selection(&ClearSelection, window, cx);
                     }
 
-                    canvas.set_active_drag(ActiveDrag::new_selection(position));
+                    // Only start a selection drag if using the Selection tool
+                    if *active_tool == Tool::Selection {
+                        canvas.set_active_drag(ActiveDrag::new_selection(position));
+                    }
                     canvas.mark_dirty(cx);
                 }
             }
@@ -488,6 +491,13 @@ impl CanvasElement {
                 drag_type: active_drag.drag_type.clone(),
             };
             canvas.set_active_drag(new_drag.clone());
+
+            // For any non-Selection tool, only allow specific drag types
+            if active_tool != Tool::Selection && matches!(new_drag.drag_type, DragType::Selection) {
+                // If using a non-Selection tool but having a Selection drag, cancel it
+                canvas.clear_active_drag();
+                return;
+            }
 
             match new_drag.drag_type {
                 DragType::Selection => {

--- a/src/canvas_element.rs
+++ b/src/canvas_element.rs
@@ -1,5 +1,6 @@
 #![allow(unused, dead_code)]
 use crate::interactivity::{ResizeHandle, ResizeOperation};
+use crate::tools::ActiveTool;
 use gpui::{
     hsla, prelude::*, px, relative, App, BorderStyle, ContentMask, DispatchPhase, ElementId,
     Entity, Focusable, Hitbox, Hsla, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent,
@@ -172,7 +173,7 @@ fn point_in_resize_handle(point: Point<f32>, node_bounds: &Bounds<f32>) -> Optio
 }
 
 use crate::scene_graph::SceneGraph;
-use crate::theme::Theme;
+use crate::theme::{ActiveTheme, Theme};
 use crate::AppState;
 use crate::{
     canvas::{register_canvas_action, ClearSelection, LunaCanvas},
@@ -271,7 +272,7 @@ impl CanvasElement {
 
         // Test each node to see if it contains this point
         // Iterate in reverse order to match the painting order (last node is visually on top)
-        for node in canvas.nodes.iter().rev() {
+        for node in canvas.nodes().iter().rev() {
             let node_bounds = node.bounds();
             if node_bounds.contains(&canvas_point) {
                 return Some(node.id());
@@ -294,13 +295,15 @@ impl CanvasElement {
         let position = event.position;
         let canvas_point = point(position.x.0, position.y.0);
 
-        match canvas.active_tool {
+        let active_tool = cx.active_tool().clone();
+
+        match *active_tool {
             Tool::Selection => {
                 // First, check if we've clicked on a resize handle when only a single node is selected
-                if canvas.selected_nodes.len() == 1 {
+                if canvas.selected_nodes().len() == 1 {
                     // Get the bounds of the selected node
-                    let selected_node_id = *canvas.selected_nodes.iter().next().unwrap();
-                    if let Some(node) = canvas.nodes.iter().find(|n| n.id() == selected_node_id) {
+                    let selected_node_id = *canvas.selected_nodes().iter().next().unwrap();
+                    if let Some(node) = canvas.nodes().iter().find(|n| n.id() == selected_node_id) {
                         let node_layout = node.layout();
 
                         // Create node bounds to check for resize handle hits
@@ -324,7 +327,7 @@ impl CanvasElement {
                             );
 
                             // Start a resize drag operation
-                            canvas.active_drag = Some(ActiveDrag::new_resize(position, resize_op));
+                            canvas.set_active_drag(ActiveDrag::new_resize(position, resize_op));
                             canvas.mark_dirty(cx);
                             cx.stop_propagation();
                             return;
@@ -358,7 +361,7 @@ impl CanvasElement {
                         canvas.save_selected_nodes_positions();
 
                         // Start a move elements drag operation
-                        canvas.active_drag = Some(ActiveDrag::new_move_elements(position));
+                        canvas.set_active_drag(ActiveDrag::new_move_elements(position));
                     }
 
                     canvas.mark_dirty(cx);
@@ -369,7 +372,7 @@ impl CanvasElement {
                         canvas.clear_selection(&ClearSelection, window, cx);
                     }
 
-                    canvas.active_drag = Some(ActiveDrag::new_selection(position));
+                    canvas.set_active_drag(ActiveDrag::new_selection(position));
                     canvas.mark_dirty(cx);
                 }
             }
@@ -378,7 +381,7 @@ impl CanvasElement {
                 let new_node_id = canvas.generate_id();
 
                 let active_drag = ActiveDrag::new_create_element(position);
-                canvas.active_element_draw = Some((new_node_id, NodeType::Rectangle, active_drag));
+                canvas.set_active_element_draw((new_node_id, NodeType::Rectangle, active_drag));
                 canvas.mark_dirty(cx);
             }
             _ => {}
@@ -402,10 +405,11 @@ impl CanvasElement {
         let app_state = canvas.app_state().clone().read(cx);
         let current_background_color = app_state.current_background_color.clone();
         let current_border_color = app_state.current_border_color.clone();
+        let active_tool = *cx.active_tool().clone();
 
         // Check if we have an active element draw operation
-        if let Some((node_id, node_type, active_drag)) = canvas.active_element_draw.take() {
-            match (node_type, &canvas.active_tool) {
+        if let Some((node_id, node_type, active_drag)) = canvas.active_element_draw().take() {
+            match (node_type, active_tool) {
                 (NodeType::Rectangle, Tool::Rectangle) => {
                     // Calculate rectangle dimensions
                     let start_pos = active_drag.start_position;
@@ -443,11 +447,11 @@ impl CanvasElement {
         }
 
         // Handle ending drag operations
-        if let Some(active_drag) = canvas.active_drag.take() {
+        if let Some(active_drag) = canvas.active_drag().take() {
             match active_drag.drag_type {
                 DragType::MoveElements => {
                     // Finalize the move by clearing initial positions
-                    canvas.element_initial_positions.clear();
+                    canvas.element_initial_positions_mut().clear();
                 }
                 DragType::Selection => {
                     // Selection handling is already done in the drag handler
@@ -473,21 +477,22 @@ impl CanvasElement {
     ) {
         let position = event.position;
         let canvas_point = point(position.x.0, position.y.0);
+        let active_tool = *cx.active_tool().clone();
 
         // Handle active drag operations
-        if let Some(active_drag) = canvas.active_drag.take() {
+        if let Some(active_drag) = canvas.active_drag().take() {
             // Update the drag with new position
             let new_drag = ActiveDrag {
                 start_position: active_drag.start_position,
                 current_position: position,
                 drag_type: active_drag.drag_type.clone(),
             };
-            canvas.active_drag = Some(new_drag.clone());
+            canvas.set_active_drag(new_drag.clone());
 
             match new_drag.drag_type {
                 DragType::Selection => {
                     // Handle selection rectangle
-                    if canvas.active_tool == Tool::Selection {
+                    if active_tool == Tool::Selection {
                         // Calculate the selection rectangle in canvas coordinates
                         let start_pos = active_drag.start_position;
                         let min_x = start_pos.x.0.min(position.x.0);
@@ -507,7 +512,7 @@ impl CanvasElement {
 
                         // Pre-calculate all nodes that intersect with selection
                         let nodes_in_selection: HashSet<NodeId> = canvas
-                            .nodes
+                            .nodes()
                             .iter()
                             .filter(|node| bounds_intersect(&selection_bounds, &node.bounds()))
                             .map(|node| node.id())
@@ -522,7 +527,7 @@ impl CanvasElement {
                             }
                         } else {
                             // Replace selection
-                            if nodes_in_selection != canvas.selected_nodes {
+                            if nodes_in_selection != canvas.selected_nodes().clone() {
                                 canvas.clear_selection(&ClearSelection, window, cx);
                                 for node_id in nodes_in_selection {
                                     canvas.select_node(node_id);
@@ -533,7 +538,7 @@ impl CanvasElement {
                 }
                 DragType::MoveElements => {
                     // Move selected elements based on drag delta
-                    if !canvas.selected_nodes.is_empty() {
+                    if !canvas.selected_nodes().is_empty() {
                         // Calculate the drag delta in canvas coordinates
                         let delta = new_drag.delta();
 
@@ -546,15 +551,13 @@ impl CanvasElement {
                 }
                 DragType::Resize(mut resize_op) => {
                     // Handle resize operation
-                    if canvas.selected_nodes.len() == 1 {
+                    if canvas.selected_nodes().len() == 1 {
                         // Get the zoom value before any mutable borrows
                         let zoom = canvas.zoom();
 
                         // Get the selected node
-                        let selected_node_id = *canvas.selected_nodes.iter().next().unwrap();
-                        if let Some(node) =
-                            canvas.nodes.iter_mut().find(|n| n.id() == selected_node_id)
-                        {
+                        let selected_node_id = *canvas.selected_nodes().iter().next().unwrap();
+                        if let Some(node) = canvas.get_node_mut(selected_node_id) {
                             // Convert window delta to canvas delta
                             let delta = Point::new(
                                 (position.x.0 - active_drag.start_position.x.0) / zoom,
@@ -721,7 +724,7 @@ impl CanvasElement {
                                 current_position: position,
                                 drag_type: DragType::Resize(resize_op),
                             };
-                            canvas.active_drag = Some(updated_drag);
+                            canvas.set_active_drag(updated_drag);
                         }
                     }
                 }
@@ -731,15 +734,15 @@ impl CanvasElement {
         }
 
         // Handle rectangle drawing
-        if let Some(active_draw) = canvas.active_element_draw.take() {
-            match canvas.active_tool {
+        if let Some(active_draw) = canvas.active_element_draw().take() {
+            match *cx.active_tool().clone() {
                 Tool::Rectangle => {
                     let new_drag = ActiveDrag {
                         start_position: active_draw.2.start_position,
                         current_position: position,
                         drag_type: DragType::CreateElement,
                     };
-                    canvas.active_element_draw = Some((active_draw.0, active_draw.1, new_drag));
+                    canvas.set_active_element_draw((active_draw.0, active_draw.1, new_drag));
                     canvas.mark_dirty(cx);
                 }
                 _ => {}
@@ -760,8 +763,8 @@ impl CanvasElement {
         let hovered = Self::find_top_node_at_point(canvas, canvas_point, cx);
 
         // Only update and redraw if hover state changed
-        if canvas.hovered_node != hovered {
-            canvas.hovered_node = hovered;
+        if canvas.hovered_node() != hovered {
+            canvas.set_hovered_node(hovered);
             canvas.mark_dirty(cx);
         }
     }
@@ -937,6 +940,7 @@ impl CanvasElement {
 
     fn paint_nodes(&self, layout: &CanvasLayout, window: &mut Window, cx: &mut App) {
         let canvas = self.canvas.clone();
+        let theme = cx.theme().clone();
 
         // Collect ALL data we need up front to avoid any borrow issues
         struct NodeRenderInfo {
@@ -949,45 +953,44 @@ impl CanvasElement {
         }
 
         // Get all the data we need in one place
-        let (nodes_to_render, theme, selected_node_ids, hovered_node) =
-            canvas.update(cx, |canvas, cx| {
-                let visible_nodes = canvas.visible_nodes(cx);
-                let scene_graph = canvas.scene_graph().read(cx);
-                let selected_nodes = canvas.selected_nodes.clone();
-                let theme = canvas.theme.clone();
-                let hovered_node = canvas.hovered_node.clone();
+        let (nodes_to_render, selected_node_ids, hovered_node) = canvas.update(cx, |canvas, cx| {
+            let visible_nodes = canvas.visible_nodes(cx);
+            let scene_graph = canvas.scene_graph().read(cx);
+            let selected_nodes = canvas.selected_nodes().clone();
+            let theme = cx.theme().clone();
+            let hovered_node = canvas.hovered_node().clone();
 
-                // Collect all node rendering information into owned structures
-                let mut nodes_to_render = Vec::new();
+            // Collect all node rendering information into owned structures
+            let mut nodes_to_render = Vec::new();
 
-                for node in visible_nodes {
-                    let node_id = node.id();
+            for node in visible_nodes {
+                let node_id = node.id();
 
-                    if let Some(scene_node_id) = scene_graph.get_scene_node_id(node_id) {
-                        if let Some(world_bounds) = scene_graph.get_world_bounds(scene_node_id) {
-                            nodes_to_render.push(NodeRenderInfo {
-                                node_id,
-                                bounds: gpui::Bounds {
-                                    origin: gpui::Point::new(
-                                        gpui::Pixels(world_bounds.origin.x),
-                                        gpui::Pixels(world_bounds.origin.y),
-                                    ),
-                                    size: gpui::Size::new(
-                                        gpui::Pixels(world_bounds.size.width),
-                                        gpui::Pixels(world_bounds.size.height),
-                                    ),
-                                },
-                                fill_color: node.fill(),
-                                border_color: node.border_color(),
-                                border_width: node.border_width(),
-                                corner_radius: node.corner_radius(),
-                            });
-                        }
+                if let Some(scene_node_id) = scene_graph.get_scene_node_id(node_id) {
+                    if let Some(world_bounds) = scene_graph.get_world_bounds(scene_node_id) {
+                        nodes_to_render.push(NodeRenderInfo {
+                            node_id,
+                            bounds: gpui::Bounds {
+                                origin: gpui::Point::new(
+                                    gpui::Pixels(world_bounds.origin.x),
+                                    gpui::Pixels(world_bounds.origin.y),
+                                ),
+                                size: gpui::Size::new(
+                                    gpui::Pixels(world_bounds.size.width),
+                                    gpui::Pixels(world_bounds.size.height),
+                                ),
+                            },
+                            fill_color: node.fill(),
+                            border_color: node.border_color(),
+                            border_width: node.border_width(),
+                            corner_radius: node.corner_radius(),
+                        });
                     }
                 }
+            }
 
-                (nodes_to_render, theme, selected_nodes, hovered_node)
-            });
+            (nodes_to_render, selected_nodes, hovered_node)
+        });
 
         window.paint_layer(layout.hitbox.bounds, |window| {
             // FIRST PASS: Paint all nodes and hover effects
@@ -1233,7 +1236,7 @@ impl Element for CanvasElement {
                 // Check for active drags in the canvas itself
                 let has_active_drag = {
                     let canvas = self.canvas.read(cx);
-                    canvas.active_drag.is_some()
+                    canvas.active_drag().is_some()
                 };
 
                 if !has_active_drag {
@@ -1256,6 +1259,8 @@ impl Element for CanvasElement {
         cx: &mut gpui::App,
     ) {
         let canvas = self.canvas.clone();
+        let active_tool = *cx.active_tool().clone();
+        let theme = cx.theme().clone();
         // let key_context = self.canvas.update(cx, |canvas, cx| canvas.key_context());
 
         // window.set_key_context(key_context);
@@ -1279,14 +1284,12 @@ impl Element for CanvasElement {
 
                 // Read canvas once to get all needed data
                 let canvas_read = canvas_clone.read(cx);
-                let active_drag = canvas_read.active_drag.clone();
-                let active_element_draw = canvas_read.active_element_draw.clone();
-                let active_tool = canvas_read.active_tool.clone();
-                let theme = &canvas_read.theme;
+                let active_drag = canvas_read.active_drag().clone();
+                let active_element_draw = canvas_read.active_element_draw().clone();
 
                 // Paint selection rectangle if dragging with selection tool
                 if let Some(active_drag) = active_drag {
-                    self.paint_selection(&active_drag, layout, window, theme);
+                    self.paint_selection(&active_drag, layout, window, &theme.clone());
                 }
 
                 // Paint rectangle preview if drawing with rectangle tool

--- a/src/canvas_element.rs
+++ b/src/canvas_element.rs
@@ -179,7 +179,7 @@ use crate::{
     interactivity::{ActiveDrag, DragType},
     node::{NodeCommon, NodeId, NodeLayout, NodeType, RectangleNode},
     util::{round_to_pixel, rounded_point},
-    GlobalState, ToolKind,
+    GlobalState, Tool,
 };
 
 #[derive(Clone)]
@@ -295,7 +295,7 @@ impl CanvasElement {
         let canvas_point = point(position.x.0, position.y.0);
 
         match canvas.active_tool {
-            ToolKind::Selection => {
+            Tool::Selection => {
                 // First, check if we've clicked on a resize handle when only a single node is selected
                 if canvas.selected_nodes.len() == 1 {
                     // Get the bounds of the selected node
@@ -373,7 +373,7 @@ impl CanvasElement {
                     canvas.mark_dirty(cx);
                 }
             }
-            ToolKind::Rectangle => {
+            Tool::Rectangle => {
                 // Use the generate_id method directly since it already returns the correct type
                 let new_node_id = canvas.generate_id();
 
@@ -406,7 +406,7 @@ impl CanvasElement {
         // Check if we have an active element draw operation
         if let Some((node_id, node_type, active_drag)) = canvas.active_element_draw.take() {
             match (node_type, &canvas.active_tool) {
-                (NodeType::Rectangle, ToolKind::Rectangle) => {
+                (NodeType::Rectangle, Tool::Rectangle) => {
                     // Calculate rectangle dimensions
                     let start_pos = active_drag.start_position;
                     let end_pos = active_drag.current_position;
@@ -487,7 +487,7 @@ impl CanvasElement {
             match new_drag.drag_type {
                 DragType::Selection => {
                     // Handle selection rectangle
-                    if canvas.active_tool == ToolKind::Selection {
+                    if canvas.active_tool == Tool::Selection {
                         // Calculate the selection rectangle in canvas coordinates
                         let start_pos = active_drag.start_position;
                         let min_x = start_pos.x.0.min(position.x.0);
@@ -733,7 +733,7 @@ impl CanvasElement {
         // Handle rectangle drawing
         if let Some(active_draw) = canvas.active_element_draw.take() {
             match canvas.active_tool {
-                ToolKind::Rectangle => {
+                Tool::Rectangle => {
                     let new_drag = ActiveDrag {
                         start_position: active_draw.2.start_position,
                         current_position: position,
@@ -1292,7 +1292,7 @@ impl Element for CanvasElement {
                 // Paint rectangle preview if drawing with rectangle tool
                 if let Some((node_id, node_type, drag)) = active_element_draw {
                     match active_tool {
-                        ToolKind::Rectangle => {
+                        Tool::Rectangle => {
                             self.paint_draw_rectangle(node_id, &drag, layout, window, cx);
                         }
                         _ => {}

--- a/src/luna.rs
+++ b/src/luna.rs
@@ -201,6 +201,12 @@ impl Luna {
         cx.set_global(GlobalTool(Arc::new(Tool::Rectangle)));
         cx.notify();
     }
+    fn select_all_nodes(&mut self, _: &SelectAll, _window: &mut Window, cx: &mut Context<Self>) {
+        self.canvas.update(cx, |canvas, cx| {
+            canvas.select_all_nodes();
+        });
+        cx.notify();
+    }
 }
 
 impl Render for Luna {
@@ -235,6 +241,7 @@ impl Render for Luna {
             .on_action(cx.listener(Self::activate_hand_tool))
             .on_action(cx.listener(Self::activate_selection_tool))
             .on_action(cx.listener(Self::activate_rectangle_tool))
+            .on_action(cx.listener(Self::select_all_nodes))
             .child(CanvasElement::new(&self.canvas, &self.scene_graph, cx))
             .child(self.inspector.clone())
             .child(self.sidebar.clone())

--- a/src/luna.rs
+++ b/src/luna.rs
@@ -20,7 +20,6 @@ use anyhow::Result;
 use assets::Assets;
 use canvas::LunaCanvas;
 use canvas_element::CanvasElement;
-use clipboard::GlobalClipboard;
 use gpui::{
     actions, div, hsla, point, prelude::*, px, svg, App, Application, AssetSource, BoxShadow,
     ElementId, Entity, FocusHandle, Focusable, Global, Hsla, IntoElement, KeyBinding, Keystroke,
@@ -39,7 +38,6 @@ use util::keystroke_builder;
 mod assets;
 mod canvas;
 mod canvas_element;
-mod clipboard;
 mod css_parser;
 mod interactivity;
 mod node;
@@ -209,47 +207,21 @@ impl Luna {
         });
         cx.notify();
     }
-    
-    // Handler for the Copy action
-    fn copy_selected_nodes(&mut self, _: &Copy, _window: &mut Window, cx: &mut Context<Self>) {
-        self.canvas.update(cx, |canvas, cx| {
-            canvas.copy_selected_nodes(cx);
-        });
-        cx.notify();
-    }
-    
-    // Handler for the Cut action
-    fn cut_selected_nodes(&mut self, _: &Cut, _window: &mut Window, cx: &mut Context<Self>) {
-        self.canvas.update(cx, |canvas, cx| {
-            canvas.cut_selected_nodes(cx);
-        });
-        cx.notify();
-    }
-    
-    // Handler for the Paste action
-    fn paste_nodes(&mut self, _: &Paste, _window: &mut Window, cx: &mut Context<Self>) {
-        self.canvas.update(cx, |canvas, cx| {
-            canvas.paste_nodes(cx);
-        });
-        cx.notify();
-    }
-    
+
     // Handler for the Delete action
     fn delete_selected_nodes(&mut self, _: &Delete, _window: &mut Window, cx: &mut Context<Self>) {
         self.canvas.update(cx, |canvas, cx| {
-            // Get selected nodes and remove them
-            // We're using methods rather than accessing private fields directly
-            let selected_nodes = canvas.get_root_nodes()
+            let selected_nodes = canvas
+                .get_root_nodes()
                 .into_iter()
                 .filter(|&node_id| canvas.is_node_selected(node_id))
                 .collect::<Vec<_>>();
-                
+
             for node_id in selected_nodes {
                 canvas.remove_node(node_id, cx);
             }
             canvas.mark_dirty(cx);
         });
-        cx.notify();
     }
 }
 
@@ -286,9 +258,6 @@ impl Render for Luna {
             .on_action(cx.listener(Self::activate_selection_tool))
             .on_action(cx.listener(Self::activate_rectangle_tool))
             .on_action(cx.listener(Self::select_all_nodes))
-            .on_action(cx.listener(Self::copy_selected_nodes))
-            .on_action(cx.listener(Self::cut_selected_nodes))
-            .on_action(cx.listener(Self::paste_nodes))
             .on_action(cx.listener(Self::delete_selected_nodes))
             .child(CanvasElement::new(&self.canvas, &self.scene_graph, cx))
             .child(self.inspector.clone())
@@ -306,7 +275,6 @@ fn init_globals(cx: &mut App) {
     cx.set_global(GlobalTheme(Arc::new(Theme::default())));
     cx.set_global(GlobalTool(Arc::new(Tool::default())));
     cx.set_global(GlobalState::new());
-    cx.set_global(GlobalClipboard::default());
 }
 
 /// Application entry point
@@ -331,6 +299,7 @@ fn main() {
                 KeyBinding::new("a", SelectionTool, None),
                 KeyBinding::new("r", RectangleTool, None),
                 KeyBinding::new("delete", Delete, None),
+                KeyBinding::new("backspace", Delete, None),
                 KeyBinding::new("cmd-a", SelectAll, None),
                 KeyBinding::new("cmd-v", Paste, None),
                 KeyBinding::new("cmd-c", Copy, None),

--- a/src/node.rs
+++ b/src/node.rs
@@ -137,7 +137,7 @@ pub trait NodeCommon: std::fmt::Debug {
 /// As the fundamental building block in the canvas system, rectangles
 /// serve as the basis for many other visual elements and are optimized
 /// for efficient rendering and manipulation.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RectangleNode {
     pub id: NodeId,
     pub layout: NodeLayout,

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -24,11 +24,13 @@ use gpui::{
     MenuItem, Modifiers, Pixels, Point, SharedString, TitlebarOptions, UpdateGlobal, WeakEntity,
     Window, WindowBackgroundAppearance, WindowOptions,
 };
+use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
 use std::{fs, path::PathBuf};
 use strum::Display;
 
-#[derive(Default, Debug, Display, Clone, PartialEq)]
-pub enum ToolKind {
+#[derive(Default, Debug, Display, Clone, Copy, PartialEq)]
+pub enum Tool {
     /// Standard selection tool for clicking, dragging, and manipulating elements
     #[default]
     Selection,
@@ -63,29 +65,58 @@ pub enum ToolKind {
     ZoomOut,
 }
 
-impl ToolKind {
+impl Tool {
     pub fn src(self) -> SharedString {
         match self {
-            ToolKind::Selection => "svg/arrow_pointer.svg".into(),
-            ToolKind::Arrow => "svg/arrow_tool.svg".into(),
-            ToolKind::Frame => "svg/frame.svg".into(),
-            ToolKind::Hand => "svg/hand.svg".into(),
-            ToolKind::Image => "svg/image.svg".into(),
-            ToolKind::Line => "svg/line_tool.svg".into(),
-            ToolKind::Pen => "svg/pen_tool.svg".into(),
-            ToolKind::Pencil => "svg/pencil.svg".into(),
-            ToolKind::Prompt => "svg/prompt.svg".into(),
-            ToolKind::ElementLibrary => "svg/shapes.svg".into(),
-            ToolKind::Rectangle => "svg/square.svg".into(),
-            ToolKind::TextCursor => "svg/text_cursor.svg".into(),
-            ToolKind::ZoomIn => "svg/zoom_in.svg".into(),
-            ToolKind::ZoomOut => "svg/zoom_out.svg".into(),
+            Tool::Selection => "svg/arrow_pointer.svg".into(),
+            Tool::Arrow => "svg/arrow_tool.svg".into(),
+            Tool::Frame => "svg/frame.svg".into(),
+            Tool::Hand => "svg/hand.svg".into(),
+            Tool::Image => "svg/image.svg".into(),
+            Tool::Line => "svg/line_tool.svg".into(),
+            Tool::Pen => "svg/pen_tool.svg".into(),
+            Tool::Pencil => "svg/pencil.svg".into(),
+            Tool::Prompt => "svg/prompt.svg".into(),
+            Tool::ElementLibrary => "svg/shapes.svg".into(),
+            Tool::Rectangle => "svg/square.svg".into(),
+            Tool::TextCursor => "svg/text_cursor.svg".into(),
+            Tool::ZoomIn => "svg/zoom_in.svg".into(),
+            Tool::ZoomOut => "svg/zoom_out.svg".into(),
         }
     }
 }
 
+#[derive(Clone, Debug)]
+pub struct GlobalTool(pub Arc<Tool>);
+
+impl Deref for GlobalTool {
+    type Target = Arc<Tool>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for GlobalTool {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl Global for GlobalTool {}
+
+pub trait ActiveTool {
+    fn active_tool(&self) -> &Arc<Tool>;
+}
+
+impl ActiveTool for App {
+    fn active_tool(&self) -> &Arc<Tool> {
+        &self.global::<GlobalTool>().0
+    }
+}
+
 /// Returns a [ToolButton]
-pub fn tool_button(tool: ToolKind) -> ToolButton {
+pub fn tool_button(tool: Tool) -> ToolButton {
     ToolButton::new(tool)
 }
 
@@ -102,13 +133,13 @@ pub fn tool_button(tool: ToolKind) -> ToolButton {
 #[derive(IntoElement)]
 pub struct ToolButton {
     /// The tool this button represents
-    tool_kind: ToolKind,
+    tool_kind: Tool,
     /// Whether this tool is currently unavailable
     disabled: bool,
 }
 
 impl ToolButton {
-    pub fn new(tool: ToolKind) -> Self {
+    pub fn new(tool: Tool) -> Self {
         ToolButton {
             tool_kind: tool,
             disabled: false,
@@ -125,15 +156,16 @@ impl RenderOnce for ToolButton {
     fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
         let theme = Theme::get_global(cx);
         let state = GlobalState::get(cx);
+        let active_tool = cx.active_tool().clone();
 
         let tool_kind = self.tool_kind.clone();
-        let selected = false;
+        let selected = *active_tool == tool_kind;
 
         let icon_color = match (selected, self.disabled) {
             (true, true) => theme.tokens.active_border.alpha(0.5), // Use active_border for selected but disabled
             (true, false) => theme.tokens.active_border, // Use active_border for selected tools
-            (false, true) => theme.tokens.overlay1, // Use overlay1 for disabled tools
-            (false, false) => theme.tokens.subtext0, // Use subtext0 for normal tools
+            (false, true) => theme.tokens.overlay1,      // Use overlay1 for disabled tools
+            (false, false) => theme.tokens.subtext0,     // Use subtext0 for normal tools
         };
 
         div()
@@ -234,7 +266,7 @@ impl RenderOnce for ToolButton {
 ///
 /// ToolStrip creates a vertical strip of tool buttons, logically grouped with dividers
 /// to create a cohesive and organized tool selection UI. It implements:
-/// 
+///
 /// - Visual categorization of related tools (selection, drawing, shapes, etc.)
 /// - Consistent spacing and alignment of tool buttons
 /// - Theme-appropriate styling for the toolbar container
@@ -286,23 +318,23 @@ impl RenderOnce for ToolStrip {
                     .flex_col()
                     .items_center()
                     .gap(px(9.))
-                    .child(tool_button(ToolKind::Selection))
-                    .child(tool_button(ToolKind::Hand))
+                    .child(tool_button(Tool::Selection))
+                    .child(tool_button(Tool::Hand))
                     .child(tool_divider())
-                    .child(tool_button(ToolKind::Prompt).disabled(true))
+                    .child(tool_button(Tool::Prompt).disabled(true))
                     .child(tool_divider())
-                    .child(tool_button(ToolKind::Pencil).disabled(true))
-                    .child(tool_button(ToolKind::Pen).disabled(true))
-                    .child(tool_button(ToolKind::TextCursor).disabled(true))
+                    .child(tool_button(Tool::Pencil).disabled(true))
+                    .child(tool_button(Tool::Pen).disabled(true))
+                    .child(tool_button(Tool::TextCursor).disabled(true))
                     .child(tool_divider())
-                    .child(tool_button(ToolKind::Frame).disabled(true))
-                    .child(tool_button(ToolKind::Rectangle))
-                    .child(tool_button(ToolKind::Line).disabled(true))
+                    .child(tool_button(Tool::Frame).disabled(true))
+                    .child(tool_button(Tool::Rectangle))
+                    .child(tool_button(Tool::Line).disabled(true))
                     .child(tool_divider())
-                    .child(tool_button(ToolKind::Image).disabled(true))
-                    .child(tool_button(ToolKind::ElementLibrary).disabled(true))
+                    .child(tool_button(Tool::Image).disabled(true))
+                    .child(tool_button(Tool::ElementLibrary).disabled(true))
                     .child(tool_divider())
-                    .child(tool_button(ToolKind::Arrow).disabled(true)),
+                    .child(tool_button(Tool::Arrow).disabled(true)),
             )
             .child(
                 div().w_full().flex().flex_col().items_center(), // .child(CurrentColorTool::new()),

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -180,10 +180,12 @@ impl RenderOnce for ToolButton {
             .when(!self.disabled, |div| {
                 div.hover(|div| div.bg(theme.tokens.surface1)) // Use surface1 for hover background
             })
-            // .on_click(move |_, _, cx| {
-            //     let tool_kind = tool_kind.clone();
-            //     GlobalState::update_global(cx, |state, _| state.active_tool = tool_kind.clone())
-            // })
+            .when(!self.disabled, |div| {
+                let tool = tool_kind.clone();
+                div.on_click(move |_event, _phase, cx2| {
+                    cx2.set_global(GlobalTool(Arc::new(tool.clone())));
+                })
+            })
             .child(
                 svg()
                     .path(self.tool_kind.src())

--- a/src/ui/inspector.rs
+++ b/src/ui/inspector.rs
@@ -98,7 +98,7 @@ impl Inspector {
     /// Updates the inspector properties based on the currently selected nodes
     pub fn update_selected_node_properties(&mut self, cx: &mut Context<Self>) {
         let canvas = self.canvas.clone();
-        let selected_node_set = canvas.read(cx).selected_nodes.clone();
+        let selected_node_set = canvas.read(cx).selected_nodes().clone();
         let selected_nodes = NodeSelection::from(selected_node_set);
 
         // Clear the current properties
@@ -115,7 +115,7 @@ impl Inspector {
             }
             NodeSelection::Single(node_id) => {
                 let canvas_read = canvas.read(cx);
-                if let Some(node) = canvas_read.nodes.iter().find(|node| node.id() == node_id) {
+                if let Some(node) = canvas_read.nodes().iter().find(|node| node.id() == node_id) {
                     self.properties.x.push(node.layout().x);
                     self.properties.y.push(node.layout().y);
                     self.properties.width.push(node.layout().width);
@@ -139,7 +139,10 @@ impl Inspector {
 
                 // Collect all values first
                 for node_id in &nodes {
-                    if let Some(node) = canvas_read.nodes.iter().find(|node| node.id() == *node_id)
+                    if let Some(node) = canvas_read
+                        .nodes()
+                        .iter()
+                        .find(|node| node.id() == *node_id)
                     {
                         all_x.push(node.layout().x);
                         all_y.push(node.layout().y);

--- a/src/ui/layer_list.rs
+++ b/src/ui/layer_list.rs
@@ -92,7 +92,7 @@ impl RenderOnce for LayerList {
         let canvas = self.canvas.read(cx);
 
         // Add all nodes to the layer list
-        for node in &canvas.nodes {
+        for node in canvas.nodes() {
             let kind = NodeType::Rectangle; // We only have rectangle nodes now
 
             let name = format!("Node {}", node.id.0);

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -22,8 +22,7 @@ pub struct Sidebar {
 }
 
 impl Sidebar {
-    pub fn new(weak_canvas: WeakEntity<LunaCanvas>) -> Self {
-        let canvas = weak_canvas.upgrade().expect("Canvas should be alive");
+    pub fn new(canvas: Entity<LunaCanvas>) -> Self {
         Self { canvas }
     }
 }


### PR DESCRIPTION
This PR adds some initial keybindings (delete, switch tools with `h`, `v`, `r`) and fixes a major bug with the css import module.

**The css import problem**

The imported nodes weren't being assigned ids, respecting the ids that the canvas was producing. This meant that when new nodes were created, they were clobbering imported nodes.