### PR TITLE
fix(ui): replace theme color with hardcoded green outline

### DIFF
--- a/crates/canvas/src/canvas_element.rs
+++ b/crates/canvas/src/canvas_element.rs
@@ -1214,7 +1214,7 @@ impl CanvasElement {
             window.paint_quad(gpui::fill(rect_bounds, theme.tokens.overlay2.opacity(0.25)));
             window.paint_quad(gpui::outline(
                 rect_bounds,
-                theme.tokens.active_border,
+                hsla(120.0 / 360.0, 1.0, 0.5, 1.0), // Green color
                 BorderStyle::Solid,
             ));
             window.request_animation_frame();


### PR DESCRIPTION
## Changes

This PR modifies the `CanvasElement` implementation to replace a theme-based color for an outline with a hardcoded green color.

### Details

- Replaced the theme-based color (`theme.tokens.active_border`) with a hardcoded green color
- The new color is specified using the `hsla` function: `hsla(120.0 / 360.0, 1.0, 0.5, 1.0)`
- This represents a pure green color with 100% saturation, 50% lightness, and full opacity

### Reasoning

The PR changes the outline color to be more consistent and not depend on theme variations.

> Created by **GitHub Ace** · [View Channel](https://ace.githubnext.com/iamnbutler/luna/01K77T6BZKCEPJ1TAYSGH2BWQP)