### PR TITLE
fix: Display selected node properties in the inspector

### DIFF
--- a/crates/ui/src/property.rs
+++ b/crates/ui/src/property.rs
@@ -153,7 +153,11 @@ impl InteractivePropertyInput {
         self.content = match &self.value {
             None => String::new(),
             Some(values) if values.is_empty() => String::new(),
-            Some(values) if values.len() == 1 => format!("{}", values[0]),
+            Some(values) if values.len() == 1 => {
+                // Round to one decimal place for display
+                let rounded = (values[0] * 10.0).round() / 10.0;
+                format!("{}", rounded)
+            }
             Some(_) => String::from("Mixed"),
         };
 


### PR DESCRIPTION
This PR fixes inspector properties so that they correctly show their initial values, and update those values as they change.

<img width="3072" height="1730" alt="CleanShot - 2025-10-25 at 20 49 47@2x" src="https://github.com/user-attachments/assets/8d69f12f-ac47-4c54-9c1e-7a8c5057a9bf" />

The inspector panel was not displaying property values (X, Y, Width, Height, etc.) for selected nodes, and inputting new values wasn't updating the nodes.

## Issues:

1. **Property values not displaying**: The `update_selected_node_properties` method only called `input.update_value()` inside the `NodeSelection::Multiple` match arm, so single node selections never updated the UI components.

2. **Update timing issues**: Property updates were being called from within the `render` method, which can cause state mutation timing problems.

3. **Missing canvas observer**: The inspector wasn't properly observing canvas changes beyond selection changes.

## Changes
- Moved input update logic outside the match statement to execute for both single and multiple node selections
- Refactored property updates out of the render method using a deferred update pattern with a `dirty` flag
- Added canvas observer to trigger updates on any canvas change (not just selection changes)
- Fixed decimal formatting in `InteractivePropertyInput` to round values to 1 decimal place for display

The inspector now correctly displays node properties when elements are selected and properly applies value changes to the canvas.