### PR TITLE
feat: Suggest .luna extension when saving

### DIFF
--- a/crates/luna/src/luna.rs
+++ b/crates/luna/src/luna.rs
@@ -304,7 +304,7 @@ impl Luna {
                         .ok()
                         .map(std::path::PathBuf::from)
                         .unwrap_or_else(|| std::path::PathBuf::from("/"));
-                    cx.prompt_for_new_path(&home_dir, None)
+                    cx.prompt_for_new_path(&home_dir, Some("untitled.luna"))
                 })?
                 .await??;
 


### PR DESCRIPTION
This PR makes it so that saving an untitled file always suggests using a `.luna` extension. 

Saved files without the extension will have it added anyways, but this makes the user experience better by hinting at that with the default name.