### PR TITLE
add: autolayout controls in properties panel

### DIFF
--- a/.spool/events/2026-01-25.jsonl
+++ b/.spool/events/2026-01-25.jsonl
@@ -77,3 +77,5 @@
 {"v":1,"op":"complete","id":"mkt4o7g1-ak7h","ts":"2026-01-25T02:56:17.772933Z","by":"@iamnbutler","branch":"autolayout-integration","d":{"resolution":"done"}}
 {"v":1,"op":"complete","id":"mkt4o7gy-e0q8","ts":"2026-01-25T02:56:17.806101Z","by":"@iamnbutler","branch":"autolayout-integration","d":{"resolution":"done"}}
 {"v":1,"op":"complete","id":"mkt4o7hw-bsz7","ts":"2026-01-25T02:56:17.843213Z","by":"@iamnbutler","branch":"autolayout-integration","d":{"resolution":"done"}}
+{"v":1,"op":"create","id":"mku3oo3s-admb","ts":"2026-01-25T18:57:11.944905Z","by":"@iamnbutler","branch":"autolayout-inspector","d":{"priority":"p1","title":"Add autolayout controls to inspector panel"}}
+{"v":1,"op":"complete","id":"mku3oo3s-admb","ts":"2026-01-25T18:57:17.731387Z","by":"@iamnbutler","branch":"autolayout-inspector","d":{"resolution":"done"}}

--- a/crates/ui_2/src/properties.rs
+++ b/crates/ui_2/src/properties.rs
@@ -4,10 +4,13 @@ use crate::components::{h_stack, panel, v_stack};
 use crate::input::{input, InputColors, InputState, InputStateEvent};
 use canvas_2::{Canvas, CanvasEvent};
 use gpui::{
-    div, px, AppContext, Context, Entity, Focusable, Hsla, IntoElement, ParentElement, Render,
-    Styled, Subscription, Window,
+    div, px, AppContext, Context, Entity, Focusable, Hsla, InteractiveElement, IntoElement,
+    ParentElement, Render, StatefulInteractiveElement, Styled, Subscription, Window,
 };
-use node_2::{CanvasPoint, CanvasSize, Fill, ShapeId, ShapeKind, Stroke};
+use node_2::{
+    CanvasPoint, CanvasSize, CrossAxisAlignment, Fill, FrameLayout, LayoutDirection,
+    MainAxisAlignment, Padding, ShapeId, ShapeKind, Stroke,
+};
 use theme_2::Theme;
 
 /// Properties panel showing details of selected shapes.
@@ -27,6 +30,9 @@ pub struct PropertiesPanel {
     stroke_color_input: Entity<InputState>,
     // Input state for corner radius
     corner_radius_input: Entity<InputState>,
+    // Layout inputs (for frames)
+    layout_gap_input: Entity<InputState>,
+    layout_padding_input: Entity<InputState>,
     // Track current selection and values to know when to update inputs
     last_selection_id: Option<ShapeId>,
     last_position: CanvasPoint,
@@ -34,6 +40,7 @@ pub struct PropertiesPanel {
     last_fill: Option<Fill>,
     last_stroke: Option<Stroke>,
     last_corner_radius: f32,
+    last_layout: Option<FrameLayout>,
     _subscriptions: Vec<Subscription>,
 }
 
@@ -47,6 +54,8 @@ impl PropertiesPanel {
         let stroke_width_input = cx.new(|cx| InputState::new_singleline(cx));
         let stroke_color_input = cx.new(|cx| InputState::new_singleline(cx));
         let corner_radius_input = cx.new(|cx| InputState::new_singleline(cx));
+        let layout_gap_input = cx.new(|cx| InputState::new_singleline(cx));
+        let layout_padding_input = cx.new(|cx| InputState::new_singleline(cx));
 
         // Subscribe to input changes
         let x_sub = cx.subscribe(&x_input, Self::on_x_changed);
@@ -58,6 +67,8 @@ impl PropertiesPanel {
         let stroke_color_sub = cx.subscribe(&stroke_color_input, Self::on_stroke_color_changed);
         let corner_radius_sub =
             cx.subscribe(&corner_radius_input, Self::on_corner_radius_changed);
+        let layout_gap_sub = cx.subscribe(&layout_gap_input, Self::on_layout_gap_changed);
+        let layout_padding_sub = cx.subscribe(&layout_padding_input, Self::on_layout_padding_changed);
 
         // Subscribe to canvas changes to update inputs
         let canvas_sub = cx.subscribe(&canvas, Self::on_canvas_changed);
@@ -73,12 +84,15 @@ impl PropertiesPanel {
             stroke_width_input,
             stroke_color_input,
             corner_radius_input,
+            layout_gap_input,
+            layout_padding_input,
             last_selection_id: None,
             last_position: CanvasPoint::default(),
             last_size: CanvasSize::default(),
             last_fill: None,
             last_stroke: None,
             last_corner_radius: 0.0,
+            last_layout: None,
             _subscriptions: vec![
                 x_sub,
                 y_sub,
@@ -88,6 +102,8 @@ impl PropertiesPanel {
                 stroke_width_sub,
                 stroke_color_sub,
                 corner_radius_sub,
+                layout_gap_sub,
+                layout_padding_sub,
                 canvas_sub,
             ],
         }
@@ -119,17 +135,19 @@ impl PropertiesPanel {
                         shape.fill.clone(),
                         shape.stroke.clone(),
                         shape.corner_radius,
+                        shape.layout.clone(),
                     )
                 })
         };
 
-        if let Some((shape_id, position, size, fill, stroke, corner_radius)) = shape_data {
+        if let Some((shape_id, position, size, fill, stroke, corner_radius, layout)) = shape_data {
             let selection_changed = self.last_selection_id != Some(shape_id);
             let position_changed = self.last_position != position;
             let size_changed = self.last_size != size;
             let fill_changed = self.last_fill != fill;
             let stroke_changed = self.last_stroke != stroke;
             let corner_radius_changed = self.last_corner_radius != corner_radius;
+            let layout_changed = self.last_layout != layout;
 
             // Update tracking
             self.last_selection_id = Some(shape_id);
@@ -138,6 +156,7 @@ impl PropertiesPanel {
             self.last_fill = fill.clone();
             self.last_stroke = stroke.clone();
             self.last_corner_radius = corner_radius;
+            self.last_layout = layout.clone();
 
             // Update inputs if values changed, but only if not focused (avoid fighting with user)
             if selection_changed || position_changed {
@@ -200,6 +219,42 @@ impl PropertiesPanel {
                     });
                 }
             }
+
+            // Sync layout inputs
+            if selection_changed || layout_changed {
+                if let Some(ref l) = layout {
+                    if !self.layout_gap_input.focus_handle(cx).is_focused(window) {
+                        self.layout_gap_input.update(cx, |input, cx| {
+                            input.set_content(format!("{:.0}", l.gap), cx);
+                        });
+                    }
+                    if !self.layout_padding_input.focus_handle(cx).is_focused(window) {
+                        // Show uniform padding if all sides are equal, otherwise show "mixed"
+                        let p = &l.padding;
+                        if p.top == p.right && p.right == p.bottom && p.bottom == p.left {
+                            self.layout_padding_input.update(cx, |input, cx| {
+                                input.set_content(format!("{:.0}", p.top), cx);
+                            });
+                        } else {
+                            self.layout_padding_input.update(cx, |input, cx| {
+                                input.set_content("mixed".to_string(), cx);
+                            });
+                        }
+                    }
+                } else {
+                    // No layout - clear inputs
+                    if !self.layout_gap_input.focus_handle(cx).is_focused(window) {
+                        self.layout_gap_input.update(cx, |input, cx| {
+                            input.set_content("0".to_string(), cx);
+                        });
+                    }
+                    if !self.layout_padding_input.focus_handle(cx).is_focused(window) {
+                        self.layout_padding_input.update(cx, |input, cx| {
+                            input.set_content("0".to_string(), cx);
+                        });
+                    }
+                }
+            }
         } else {
             self.last_selection_id = None;
             self.last_position = CanvasPoint::default();
@@ -207,6 +262,7 @@ impl PropertiesPanel {
             self.last_fill = None;
             self.last_stroke = None;
             self.last_corner_radius = 0.0;
+            self.last_layout = None;
         }
     }
 
@@ -447,6 +503,28 @@ impl PropertiesPanel {
         }
     }
 
+    fn on_layout_gap_changed(
+        &mut self,
+        _input: Entity<InputState>,
+        event: &InputStateEvent,
+        cx: &mut Context<Self>,
+    ) {
+        if matches!(event, InputStateEvent::TextChanged) {
+            self.apply_layout_gap(cx);
+        }
+    }
+
+    fn on_layout_padding_changed(
+        &mut self,
+        _input: Entity<InputState>,
+        event: &InputStateEvent,
+        cx: &mut Context<Self>,
+    ) {
+        if matches!(event, InputStateEvent::TextChanged) {
+            self.apply_layout_padding(cx);
+        }
+    }
+
     fn apply_corner_radius(&mut self, cx: &mut Context<Self>) {
         let value = self.corner_radius_input.read(cx).content().to_string();
         if let Ok(radius) = value.parse::<f32>() {
@@ -465,6 +543,172 @@ impl PropertiesPanel {
                     }
                 });
             }
+        }
+    }
+
+    fn apply_layout_gap(&mut self, cx: &mut Context<Self>) {
+        let value = self.layout_gap_input.read(cx).content().to_string();
+        if let Ok(gap) = value.parse::<f32>() {
+            if gap >= 0.0 {
+                let frame_id = self.canvas.update(cx, |canvas, cx| {
+                    let shape_id = canvas.selection.iter().next().copied();
+                    if let Some(shape) = shape_id.and_then(|id| {
+                        canvas.shapes.iter_mut().find(|s| s.id == id)
+                    }) {
+                        if let Some(ref mut layout) = shape.layout {
+                            layout.gap = gap;
+                        } else {
+                            shape.layout = Some(FrameLayout {
+                                gap,
+                                ..Default::default()
+                            });
+                        }
+                        cx.emit(CanvasEvent::ContentChanged);
+                        cx.notify();
+                        return Some(shape.id);
+                    }
+                    None
+                });
+                if let Some(frame_id) = frame_id {
+                    self.canvas.update(cx, |canvas, _| {
+                        canvas.apply_layout_for_frame(frame_id);
+                    });
+                }
+            }
+        }
+    }
+
+    fn apply_layout_padding(&mut self, cx: &mut Context<Self>) {
+        let value = self.layout_padding_input.read(cx).content().to_string();
+        if value == "mixed" {
+            return;
+        }
+        if let Ok(padding) = value.parse::<f32>() {
+            if padding >= 0.0 {
+                let frame_id = self.canvas.update(cx, |canvas, cx| {
+                    let shape_id = canvas.selection.iter().next().copied();
+                    if let Some(shape) = shape_id.and_then(|id| {
+                        canvas.shapes.iter_mut().find(|s| s.id == id)
+                    }) {
+                        if let Some(ref mut layout) = shape.layout {
+                            layout.padding = Padding::all(padding);
+                        } else {
+                            shape.layout = Some(FrameLayout {
+                                padding: Padding::all(padding),
+                                ..Default::default()
+                            });
+                        }
+                        cx.emit(CanvasEvent::ContentChanged);
+                        cx.notify();
+                        return Some(shape.id);
+                    }
+                    None
+                });
+                if let Some(frame_id) = frame_id {
+                    self.canvas.update(cx, |canvas, _| {
+                        canvas.apply_layout_for_frame(frame_id);
+                    });
+                }
+            }
+        }
+    }
+
+    /// Toggle autolayout on/off for selected frame
+    pub fn toggle_autolayout(&mut self, cx: &mut Context<Self>) {
+        let frame_id = self.canvas.update(cx, |canvas, cx| {
+            let shape_id = canvas.selection.iter().next().copied();
+            if let Some(shape) = shape_id.and_then(|id| {
+                canvas.shapes.iter_mut().find(|s| s.id == id)
+            }) {
+                if shape.kind == ShapeKind::Frame {
+                    if shape.layout.is_some() {
+                        shape.layout = None;
+                        cx.emit(CanvasEvent::ContentChanged);
+                        cx.notify();
+                        return None;
+                    } else {
+                        shape.layout = Some(FrameLayout::default());
+                        cx.emit(CanvasEvent::ContentChanged);
+                        cx.notify();
+                        return Some(shape.id);
+                    }
+                }
+            }
+            None
+        });
+        if let Some(frame_id) = frame_id {
+            self.canvas.update(cx, |canvas, _| {
+                canvas.apply_layout_for_frame(frame_id);
+            });
+        }
+    }
+
+    /// Set layout direction for selected frame
+    pub fn set_layout_direction(&mut self, direction: LayoutDirection, cx: &mut Context<Self>) {
+        let frame_id = self.canvas.update(cx, |canvas, cx| {
+            let shape_id = canvas.selection.iter().next().copied();
+            if let Some(shape) = shape_id.and_then(|id| {
+                canvas.shapes.iter_mut().find(|s| s.id == id)
+            }) {
+                if let Some(ref mut layout) = shape.layout {
+                    layout.direction = direction;
+                    cx.emit(CanvasEvent::ContentChanged);
+                    cx.notify();
+                    return Some(shape.id);
+                }
+            }
+            None
+        });
+        if let Some(frame_id) = frame_id {
+            self.canvas.update(cx, |canvas, _| {
+                canvas.apply_layout_for_frame(frame_id);
+            });
+        }
+    }
+
+    /// Set main axis alignment for selected frame
+    pub fn set_main_axis_alignment(&mut self, alignment: MainAxisAlignment, cx: &mut Context<Self>) {
+        let frame_id = self.canvas.update(cx, |canvas, cx| {
+            let shape_id = canvas.selection.iter().next().copied();
+            if let Some(shape) = shape_id.and_then(|id| {
+                canvas.shapes.iter_mut().find(|s| s.id == id)
+            }) {
+                if let Some(ref mut layout) = shape.layout {
+                    layout.main_axis_alignment = alignment;
+                    cx.emit(CanvasEvent::ContentChanged);
+                    cx.notify();
+                    return Some(shape.id);
+                }
+            }
+            None
+        });
+        if let Some(frame_id) = frame_id {
+            self.canvas.update(cx, |canvas, _| {
+                canvas.apply_layout_for_frame(frame_id);
+            });
+        }
+    }
+
+    /// Set cross axis alignment for selected frame
+    pub fn set_cross_axis_alignment(&mut self, alignment: CrossAxisAlignment, cx: &mut Context<Self>) {
+        let frame_id = self.canvas.update(cx, |canvas, cx| {
+            let shape_id = canvas.selection.iter().next().copied();
+            if let Some(shape) = shape_id.and_then(|id| {
+                canvas.shapes.iter_mut().find(|s| s.id == id)
+            }) {
+                if let Some(ref mut layout) = shape.layout {
+                    layout.cross_axis_alignment = alignment;
+                    cx.emit(CanvasEvent::ContentChanged);
+                    cx.notify();
+                    return Some(shape.id);
+                }
+            }
+            None
+        });
+        if let Some(frame_id) = frame_id {
+            self.canvas.update(cx, |canvas, _| {
+                canvas.apply_layout_for_frame(frame_id);
+            });
         }
     }
 
@@ -633,6 +877,279 @@ impl Render for PropertiesPanel {
                                 )),
                         ),
                 )
+                // Autolayout (only for frames)
+                .children(if shape.kind == ShapeKind::Frame {
+                    let has_layout = shape.layout.is_some();
+                    let layout = shape.layout.clone().unwrap_or_default();
+                    let this = cx.entity().clone();
+
+                    Some(
+                        v_stack()
+                            .gap(px(8.0))
+                            .child(
+                                h_stack()
+                                    .gap(px(8.0))
+                                    .items_center()
+                                    .child(
+                                        div()
+                                            .text_xs()
+                                            .text_color(theme.ui_text_muted)
+                                            .child("Autolayout"),
+                                    )
+                                    .child({
+                                        let this = this.clone();
+                                        div()
+                                            .id("autolayout-toggle")
+                                            .px(px(8.0))
+                                            .py(px(2.0))
+                                            .rounded(px(2.0))
+                                            .text_xs()
+                                            .cursor_pointer()
+                                            .bg(if has_layout {
+                                                theme.selection.opacity(0.3)
+                                            } else {
+                                                theme.ui_background
+                                            })
+                                            .border_1()
+                                            .border_color(if has_layout {
+                                                theme.selection
+                                            } else {
+                                                theme.ui_border
+                                            })
+                                            .text_color(theme.ui_text)
+                                            .child(if has_layout { "On" } else { "Off" })
+                                            .on_click(move |_, _, cx| {
+                                                this.update(cx, |panel, cx| {
+                                                    panel.toggle_autolayout(cx);
+                                                });
+                                            })
+                                    }),
+                            )
+                            .children(if has_layout {
+                                let theme_clone = theme.clone();
+                                Some(
+                                    v_stack()
+                                        .gap(px(8.0))
+                                        // Direction buttons
+                                        .child(
+                                            h_stack()
+                                                .gap(px(4.0))
+                                                .child(
+                                                    div()
+                                                        .text_xs()
+                                                        .text_color(theme_clone.ui_text_muted)
+                                                        .w(px(50.0))
+                                                        .child("Direction"),
+                                                )
+                                                .child(
+                                                    h_stack()
+                                                        .gap(px(4.0))
+                                                        .child({
+                                                            let this = this.clone();
+                                                            clickable_toggle(
+                                                                "Row",
+                                                                layout.direction == LayoutDirection::Row,
+                                                                &theme_clone,
+                                                                "dir-row",
+                                                                move |_, cx| {
+                                                                    this.update(cx, |panel, cx| {
+                                                                        panel.set_layout_direction(LayoutDirection::Row, cx);
+                                                                    });
+                                                                },
+                                                            )
+                                                        })
+                                                        .child({
+                                                            let this = this.clone();
+                                                            clickable_toggle(
+                                                                "Col",
+                                                                layout.direction == LayoutDirection::Column,
+                                                                &theme_clone,
+                                                                "dir-col",
+                                                                move |_, cx| {
+                                                                    this.update(cx, |panel, cx| {
+                                                                        panel.set_layout_direction(LayoutDirection::Column, cx);
+                                                                    });
+                                                                },
+                                                            )
+                                                        }),
+                                                ),
+                                        )
+                                        // Gap input
+                                        .child(
+                                            h_stack()
+                                                .gap(px(4.0))
+                                                .child(
+                                                    div()
+                                                        .text_xs()
+                                                        .text_color(theme_clone.ui_text_muted)
+                                                        .w(px(50.0))
+                                                        .child("Gap"),
+                                                )
+                                                .child(input_field("", &self.layout_gap_input, &theme_clone, &colors, cx)),
+                                        )
+                                        // Padding input
+                                        .child(
+                                            h_stack()
+                                                .gap(px(4.0))
+                                                .child(
+                                                    div()
+                                                        .text_xs()
+                                                        .text_color(theme_clone.ui_text_muted)
+                                                        .w(px(50.0))
+                                                        .child("Padding"),
+                                                )
+                                                .child(input_field("", &self.layout_padding_input, &theme_clone, &colors, cx)),
+                                        )
+                                        // Main axis alignment
+                                        .child(
+                                            v_stack()
+                                                .gap(px(4.0))
+                                                .child(
+                                                    div()
+                                                        .text_xs()
+                                                        .text_color(theme_clone.ui_text_muted)
+                                                        .child("Main Axis"),
+                                                )
+                                                .child(
+                                                    h_stack()
+                                                        .gap(px(2.0))
+                                                        .child({
+                                                            let this = this.clone();
+                                                            clickable_toggle(
+                                                                "Start",
+                                                                layout.main_axis_alignment == MainAxisAlignment::Start,
+                                                                &theme_clone,
+                                                                "main-start",
+                                                                move |_, cx| {
+                                                                    this.update(cx, |panel, cx| {
+                                                                        panel.set_main_axis_alignment(MainAxisAlignment::Start, cx);
+                                                                    });
+                                                                },
+                                                            )
+                                                        })
+                                                        .child({
+                                                            let this = this.clone();
+                                                            clickable_toggle(
+                                                                "Center",
+                                                                layout.main_axis_alignment == MainAxisAlignment::Center,
+                                                                &theme_clone,
+                                                                "main-center",
+                                                                move |_, cx| {
+                                                                    this.update(cx, |panel, cx| {
+                                                                        panel.set_main_axis_alignment(MainAxisAlignment::Center, cx);
+                                                                    });
+                                                                },
+                                                            )
+                                                        })
+                                                        .child({
+                                                            let this = this.clone();
+                                                            clickable_toggle(
+                                                                "End",
+                                                                layout.main_axis_alignment == MainAxisAlignment::End,
+                                                                &theme_clone,
+                                                                "main-end",
+                                                                move |_, cx| {
+                                                                    this.update(cx, |panel, cx| {
+                                                                        panel.set_main_axis_alignment(MainAxisAlignment::End, cx);
+                                                                    });
+                                                                },
+                                                            )
+                                                        })
+                                                        .child({
+                                                            let this = this.clone();
+                                                            clickable_toggle(
+                                                                "Space",
+                                                                layout.main_axis_alignment == MainAxisAlignment::SpaceBetween,
+                                                                &theme_clone,
+                                                                "main-space",
+                                                                move |_, cx| {
+                                                                    this.update(cx, |panel, cx| {
+                                                                        panel.set_main_axis_alignment(MainAxisAlignment::SpaceBetween, cx);
+                                                                    });
+                                                                },
+                                                            )
+                                                        }),
+                                                ),
+                                        )
+                                        // Cross axis alignment
+                                        .child(
+                                            v_stack()
+                                                .gap(px(4.0))
+                                                .child(
+                                                    div()
+                                                        .text_xs()
+                                                        .text_color(theme_clone.ui_text_muted)
+                                                        .child("Cross Axis"),
+                                                )
+                                                .child(
+                                                    h_stack()
+                                                        .gap(px(2.0))
+                                                        .child({
+                                                            let this = this.clone();
+                                                            clickable_toggle(
+                                                                "Start",
+                                                                layout.cross_axis_alignment == CrossAxisAlignment::Start,
+                                                                &theme_clone,
+                                                                "cross-start",
+                                                                move |_, cx| {
+                                                                    this.update(cx, |panel, cx| {
+                                                                        panel.set_cross_axis_alignment(CrossAxisAlignment::Start, cx);
+                                                                    });
+                                                                },
+                                                            )
+                                                        })
+                                                        .child({
+                                                            let this = this.clone();
+                                                            clickable_toggle(
+                                                                "Center",
+                                                                layout.cross_axis_alignment == CrossAxisAlignment::Center,
+                                                                &theme_clone,
+                                                                "cross-center",
+                                                                move |_, cx| {
+                                                                    this.update(cx, |panel, cx| {
+                                                                        panel.set_cross_axis_alignment(CrossAxisAlignment::Center, cx);
+                                                                    });
+                                                                },
+                                                            )
+                                                        })
+                                                        .child({
+                                                            let this = this.clone();
+                                                            clickable_toggle(
+                                                                "End",
+                                                                layout.cross_axis_alignment == CrossAxisAlignment::End,
+                                                                &theme_clone,
+                                                                "cross-end",
+                                                                move |_, cx| {
+                                                                    this.update(cx, |panel, cx| {
+                                                                        panel.set_cross_axis_alignment(CrossAxisAlignment::End, cx);
+                                                                    });
+                                                                },
+                                                            )
+                                                        })
+                                                        .child({
+                                                            let this = this.clone();
+                                                            clickable_toggle(
+                                                                "Stretch",
+                                                                layout.cross_axis_alignment == CrossAxisAlignment::Stretch,
+                                                                &theme_clone,
+                                                                "cross-stretch",
+                                                                move |_, cx| {
+                                                                    this.update(cx, |panel, cx| {
+                                                                        panel.set_cross_axis_alignment(CrossAxisAlignment::Stretch, cx);
+                                                                    });
+                                                                },
+                                                            )
+                                                        }),
+                                                ),
+                                        ),
+                                )
+                            } else {
+                                None
+                            }),
+                    )
+                } else {
+                    None
+                })
         } else {
             div()
                 .text_sm()
@@ -693,6 +1210,39 @@ fn color_swatch(color: Option<Hsla>, theme: &Theme) -> impl IntoElement {
         .border_1()
         .border_color(theme.ui_border)
         .bg(color.unwrap_or(gpui::hsla(0.0, 0.0, 0.9, 1.0)))
+}
+
+fn clickable_toggle<F>(
+    label: &str,
+    selected: bool,
+    theme: &Theme,
+    id: impl Into<gpui::SharedString>,
+    on_click: F,
+) -> gpui::Stateful<gpui::Div>
+where
+    F: Fn(&gpui::ClickEvent, &mut gpui::App) + 'static,
+{
+    div()
+        .id(gpui::ElementId::Name(id.into()))
+        .px(px(6.0))
+        .py(px(2.0))
+        .rounded(px(2.0))
+        .text_xs()
+        .cursor_pointer()
+        .bg(if selected {
+            theme.selection.opacity(0.3)
+        } else {
+            theme.ui_background
+        })
+        .border_1()
+        .border_color(if selected {
+            theme.selection
+        } else {
+            theme.ui_border
+        })
+        .text_color(theme.ui_text)
+        .child(label.to_string())
+        .on_click(move |event, _, cx| on_click(event, cx))
 }
 
 /// Convert HSLA color to hex string (e.g., "#FF0000")

--- a/crates/ui_2/src/properties.rs
+++ b/crates/ui_2/src/properties.rs
@@ -570,8 +570,10 @@ impl PropertiesPanel {
                     None
                 });
                 if let Some(frame_id) = frame_id {
-                    self.canvas.update(cx, |canvas, _| {
+                    self.canvas.update(cx, |canvas, cx| {
                         canvas.apply_layout_for_frame(frame_id);
+                        cx.emit(CanvasEvent::ContentChanged);
+                        cx.notify();
                     });
                 }
             }
@@ -605,8 +607,10 @@ impl PropertiesPanel {
                     None
                 });
                 if let Some(frame_id) = frame_id {
-                    self.canvas.update(cx, |canvas, _| {
+                    self.canvas.update(cx, |canvas, cx| {
                         canvas.apply_layout_for_frame(frame_id);
+                        cx.emit(CanvasEvent::ContentChanged);
+                        cx.notify();
                     });
                 }
             }
@@ -637,8 +641,10 @@ impl PropertiesPanel {
             None
         });
         if let Some(frame_id) = frame_id {
-            self.canvas.update(cx, |canvas, _| {
+            self.canvas.update(cx, |canvas, cx| {
                 canvas.apply_layout_for_frame(frame_id);
+                cx.emit(CanvasEvent::ContentChanged);
+                cx.notify();
             });
         }
     }
@@ -660,8 +666,10 @@ impl PropertiesPanel {
             None
         });
         if let Some(frame_id) = frame_id {
-            self.canvas.update(cx, |canvas, _| {
+            self.canvas.update(cx, |canvas, cx| {
                 canvas.apply_layout_for_frame(frame_id);
+                cx.emit(CanvasEvent::ContentChanged);
+                cx.notify();
             });
         }
     }
@@ -683,8 +691,10 @@ impl PropertiesPanel {
             None
         });
         if let Some(frame_id) = frame_id {
-            self.canvas.update(cx, |canvas, _| {
+            self.canvas.update(cx, |canvas, cx| {
                 canvas.apply_layout_for_frame(frame_id);
+                cx.emit(CanvasEvent::ContentChanged);
+                cx.notify();
             });
         }
     }
@@ -706,8 +716,10 @@ impl PropertiesPanel {
             None
         });
         if let Some(frame_id) = frame_id {
-            self.canvas.update(cx, |canvas, _| {
+            self.canvas.update(cx, |canvas, cx| {
                 canvas.apply_layout_for_frame(frame_id);
+                cx.emit(CanvasEvent::ContentChanged);
+                cx.notify();
             });
         }
     }

--- a/crates/ui_2/src/properties.rs
+++ b/crates/ui_2/src/properties.rs
@@ -324,34 +324,70 @@ impl PropertiesPanel {
     fn apply_position_x(&mut self, cx: &mut Context<Self>) {
         let value = self.x_input.read(cx).content().to_string();
         if let Ok(x) = value.parse::<f32>() {
-            self.canvas.update(cx, |canvas, cx| {
-                if let Some(shape) = canvas
-                    .shapes
-                    .iter_mut()
-                    .find(|s| canvas.selection.contains(&s.id))
-                {
+            let parent_frame_id = self.canvas.update(cx, |canvas, cx| {
+                let shape_id = canvas.selection.iter().next().copied();
+                if let Some(shape) = shape_id.and_then(|id| {
+                    canvas.shapes.iter_mut().find(|s| s.id == id)
+                }) {
                     shape.position.0.x = x;
                     cx.emit(CanvasEvent::ContentChanged);
                     cx.notify();
+                    // Check if shape is in a layout frame
+                    if let Some(parent_id) = shape.parent {
+                        let parent_has_layout = canvas.shapes.iter()
+                            .find(|s| s.id == parent_id)
+                            .map(|p| p.layout.is_some())
+                            .unwrap_or(false);
+                        if parent_has_layout {
+                            return Some(parent_id);
+                        }
+                    }
                 }
+                None
             });
+            // Reapply parent layout if shape is in autolayout
+            if let Some(parent_id) = parent_frame_id {
+                self.canvas.update(cx, |canvas, cx| {
+                    canvas.apply_layout_for_frame(parent_id);
+                    cx.emit(CanvasEvent::ContentChanged);
+                    cx.notify();
+                });
+            }
         }
     }
 
     fn apply_position_y(&mut self, cx: &mut Context<Self>) {
         let value = self.y_input.read(cx).content().to_string();
         if let Ok(y) = value.parse::<f32>() {
-            self.canvas.update(cx, |canvas, cx| {
-                if let Some(shape) = canvas
-                    .shapes
-                    .iter_mut()
-                    .find(|s| canvas.selection.contains(&s.id))
-                {
+            let parent_frame_id = self.canvas.update(cx, |canvas, cx| {
+                let shape_id = canvas.selection.iter().next().copied();
+                if let Some(shape) = shape_id.and_then(|id| {
+                    canvas.shapes.iter_mut().find(|s| s.id == id)
+                }) {
                     shape.position.0.y = y;
                     cx.emit(CanvasEvent::ContentChanged);
                     cx.notify();
+                    // Check if shape is in a layout frame
+                    if let Some(parent_id) = shape.parent {
+                        let parent_has_layout = canvas.shapes.iter()
+                            .find(|s| s.id == parent_id)
+                            .map(|p| p.layout.is_some())
+                            .unwrap_or(false);
+                        if parent_has_layout {
+                            return Some(parent_id);
+                        }
+                    }
                 }
+                None
             });
+            // Reapply parent layout if shape is in autolayout
+            if let Some(parent_id) = parent_frame_id {
+                self.canvas.update(cx, |canvas, cx| {
+                    canvas.apply_layout_for_frame(parent_id);
+                    cx.emit(CanvasEvent::ContentChanged);
+                    cx.notify();
+                });
+            }
         }
     }
 
@@ -359,17 +395,35 @@ impl PropertiesPanel {
         let value = self.w_input.read(cx).content().to_string();
         if let Ok(w) = value.parse::<f32>() {
             if w > 0.0 {
-                self.canvas.update(cx, |canvas, cx| {
-                    if let Some(shape) = canvas
-                        .shapes
-                        .iter_mut()
-                        .find(|s| canvas.selection.contains(&s.id))
-                    {
+                let parent_frame_id = self.canvas.update(cx, |canvas, cx| {
+                    let shape_id = canvas.selection.iter().next().copied();
+                    if let Some(shape) = shape_id.and_then(|id| {
+                        canvas.shapes.iter_mut().find(|s| s.id == id)
+                    }) {
                         shape.size.0.x = w;
                         cx.emit(CanvasEvent::ContentChanged);
                         cx.notify();
+                        // Check if shape is in a layout frame
+                        if let Some(parent_id) = shape.parent {
+                            let parent_has_layout = canvas.shapes.iter()
+                                .find(|s| s.id == parent_id)
+                                .map(|p| p.layout.is_some())
+                                .unwrap_or(false);
+                            if parent_has_layout {
+                                return Some(parent_id);
+                            }
+                        }
                     }
+                    None
                 });
+                // Reapply parent layout if shape is in autolayout
+                if let Some(parent_id) = parent_frame_id {
+                    self.canvas.update(cx, |canvas, cx| {
+                        canvas.apply_layout_for_frame(parent_id);
+                        cx.emit(CanvasEvent::ContentChanged);
+                        cx.notify();
+                    });
+                }
             }
         }
     }
@@ -378,17 +432,35 @@ impl PropertiesPanel {
         let value = self.h_input.read(cx).content().to_string();
         if let Ok(h) = value.parse::<f32>() {
             if h > 0.0 {
-                self.canvas.update(cx, |canvas, cx| {
-                    if let Some(shape) = canvas
-                        .shapes
-                        .iter_mut()
-                        .find(|s| canvas.selection.contains(&s.id))
-                    {
+                let parent_frame_id = self.canvas.update(cx, |canvas, cx| {
+                    let shape_id = canvas.selection.iter().next().copied();
+                    if let Some(shape) = shape_id.and_then(|id| {
+                        canvas.shapes.iter_mut().find(|s| s.id == id)
+                    }) {
                         shape.size.0.y = h;
                         cx.emit(CanvasEvent::ContentChanged);
                         cx.notify();
+                        // Check if shape is in a layout frame
+                        if let Some(parent_id) = shape.parent {
+                            let parent_has_layout = canvas.shapes.iter()
+                                .find(|s| s.id == parent_id)
+                                .map(|p| p.layout.is_some())
+                                .unwrap_or(false);
+                            if parent_has_layout {
+                                return Some(parent_id);
+                            }
+                        }
                     }
+                    None
                 });
+                // Reapply parent layout if shape is in autolayout
+                if let Some(parent_id) = parent_frame_id {
+                    self.canvas.update(cx, |canvas, cx| {
+                        canvas.apply_layout_for_frame(parent_id);
+                        cx.emit(CanvasEvent::ContentChanged);
+                        cx.notify();
+                    });
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- Adds UI controls for frame autolayout in the properties/inspector panel
- Toggle to enable/disable autolayout on frames
- Direction buttons (Row/Column)
- Gap and Padding input fields
- Main axis alignment buttons (Start/Center/End/SpaceBetween)
- Cross axis alignment buttons (Start/Center/End/Stretch)
- All controls immediately update the layout when interacted with

## Test plan

1. Build and run Luna: `LUNA_DEBUG=1 cargo run --bin Luna2`
2. Create a frame using the Frame tool
3. Select the frame - should see "Autolayout" section in properties panel
4. Click "Off" toggle to enable autolayout
5. Add some child shapes to the frame
6. Test direction toggle (Row/Col)
7. Test gap and padding inputs
8. Test alignment buttons
9. Verify children reposition when layout settings change