### PR TITLE
cleanup: improve test quality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ target/
 
 .DS_Store
 .idea
+.worktrees/

--- a/crates/common/src/bounds.rs
+++ b/crates/common/src/bounds.rs
@@ -273,11 +273,26 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_bounds_creation() {
+    fn from_origin_size_sets_min_to_origin() {
         let bounds = Bounds::from_origin_size(Vec2::new(10.0, 20.0), Vec2::new(100.0, 50.0));
         assert_eq!(bounds.min, Vec2::new(10.0, 20.0));
+    }
+
+    #[test]
+    fn from_origin_size_sets_max_to_origin_plus_size() {
+        let bounds = Bounds::from_origin_size(Vec2::new(10.0, 20.0), Vec2::new(100.0, 50.0));
         assert_eq!(bounds.max, Vec2::new(110.0, 70.0));
+    }
+
+    #[test]
+    fn size_returns_difference_of_max_and_min() {
+        let bounds = Bounds::from_origin_size(Vec2::new(10.0, 20.0), Vec2::new(100.0, 50.0));
         assert_eq!(bounds.size(), Vec2::new(100.0, 50.0));
+    }
+
+    #[test]
+    fn center_returns_midpoint_of_bounds() {
+        let bounds = Bounds::from_origin_size(Vec2::new(10.0, 20.0), Vec2::new(100.0, 50.0));
         assert_eq!(bounds.center(), Vec2::new(60.0, 45.0));
     }
 
@@ -315,29 +330,47 @@ mod tests {
     }
 
     #[test]
-    fn test_bounds_expand_contract() {
+    fn expand_grows_bounds_in_all_directions() {
         let bounds = Bounds::from_origin_size(Vec2::new(10.0, 20.0), Vec2::new(100.0, 50.0));
-
         let expanded = bounds.expand(10.0);
         assert_eq!(expanded.min, Vec2::new(0.0, 10.0));
         assert_eq!(expanded.max, Vec2::new(120.0, 80.0));
+    }
 
+    #[test]
+    fn contract_shrinks_bounds_in_all_directions() {
+        let bounds = Bounds::from_origin_size(Vec2::new(10.0, 20.0), Vec2::new(100.0, 50.0));
         let contracted = bounds.contract(5.0);
         assert_eq!(contracted.min, Vec2::new(15.0, 25.0));
         assert_eq!(contracted.max, Vec2::new(105.0, 65.0));
     }
 
     #[test]
-    fn test_bounds_scale() {
+    fn scale_from_center_preserves_center_point() {
         let bounds = Bounds::from_origin_size(Vec2::new(10.0, 20.0), Vec2::new(100.0, 50.0));
-
         let scaled = bounds.scale_from_center(2.0);
-        assert_eq!(scaled.center(), bounds.center()); // center should remain the same
-        assert_eq!(scaled.size(), Vec2::new(200.0, 100.0));
+        assert_eq!(scaled.center(), bounds.center());
+    }
 
-        let scaled_origin = bounds.scale_from_origin(2.0);
-        assert_eq!(scaled_origin.min, bounds.min); // origin should remain the same
-        assert_eq!(scaled_origin.size(), Vec2::new(200.0, 100.0));
+    #[test]
+    fn scale_from_center_multiplies_size() {
+        let bounds = Bounds::from_origin_size(Vec2::new(10.0, 20.0), Vec2::new(100.0, 50.0));
+        let scaled = bounds.scale_from_center(2.0);
+        assert_eq!(scaled.size(), Vec2::new(200.0, 100.0));
+    }
+
+    #[test]
+    fn scale_from_origin_preserves_min_point() {
+        let bounds = Bounds::from_origin_size(Vec2::new(10.0, 20.0), Vec2::new(100.0, 50.0));
+        let scaled = bounds.scale_from_origin(2.0);
+        assert_eq!(scaled.min, bounds.min);
+    }
+
+    #[test]
+    fn scale_from_origin_multiplies_size() {
+        let bounds = Bounds::from_origin_size(Vec2::new(10.0, 20.0), Vec2::new(100.0, 50.0));
+        let scaled = bounds.scale_from_origin(2.0);
+        assert_eq!(scaled.size(), Vec2::new(200.0, 100.0));
     }
 
     #[test]

--- a/crates/node_2/src/layout.rs
+++ b/crates/node_2/src/layout.rs
@@ -233,49 +233,114 @@ impl ChildLayout {
 mod tests {
     use super::*;
 
+    // === FrameLayout defaults ===
+
     #[test]
-    fn test_frame_layout_defaults() {
-        let layout = FrameLayout::default();
-        assert_eq!(layout.direction, LayoutDirection::Row);
-        assert_eq!(layout.main_axis_alignment, MainAxisAlignment::Start);
-        assert_eq!(layout.cross_axis_alignment, CrossAxisAlignment::Start);
-        assert_eq!(layout.gap, 0.0);
-        assert_eq!(layout.padding, Padding::default());
+    fn default_direction_is_row() {
+        assert_eq!(FrameLayout::default().direction, LayoutDirection::Row);
     }
 
     #[test]
-    fn test_frame_layout_builders() {
-        let layout = FrameLayout::column()
-            .with_gap(10.0)
-            .with_padding(20.0)
-            .with_main_axis(MainAxisAlignment::Center)
-            .with_cross_axis(CrossAxisAlignment::Stretch);
+    fn default_main_axis_alignment_is_start() {
+        assert_eq!(FrameLayout::default().main_axis_alignment, MainAxisAlignment::Start);
+    }
 
-        assert_eq!(layout.direction, LayoutDirection::Column);
+    #[test]
+    fn default_cross_axis_alignment_is_start() {
+        assert_eq!(FrameLayout::default().cross_axis_alignment, CrossAxisAlignment::Start);
+    }
+
+    #[test]
+    fn default_gap_is_zero() {
+        assert_eq!(FrameLayout::default().gap, 0.0);
+    }
+
+    #[test]
+    fn default_padding_is_zero() {
+        assert_eq!(FrameLayout::default().padding, Padding::default());
+    }
+
+    // === FrameLayout builders (each builder tested independently) ===
+
+    #[test]
+    fn row_constructor_sets_row_direction() {
+        assert_eq!(FrameLayout::row().direction, LayoutDirection::Row);
+    }
+
+    #[test]
+    fn column_constructor_sets_column_direction() {
+        assert_eq!(FrameLayout::column().direction, LayoutDirection::Column);
+    }
+
+    #[test]
+    fn with_gap_sets_gap() {
+        let layout = FrameLayout::default().with_gap(10.0);
         assert_eq!(layout.gap, 10.0);
+    }
+
+    #[test]
+    fn with_padding_sets_uniform_padding() {
+        let layout = FrameLayout::default().with_padding(20.0);
         assert_eq!(layout.padding.top, 20.0);
+        assert_eq!(layout.padding.right, 20.0);
+        assert_eq!(layout.padding.bottom, 20.0);
+        assert_eq!(layout.padding.left, 20.0);
+    }
+
+    #[test]
+    fn with_main_axis_sets_alignment() {
+        let layout = FrameLayout::default().with_main_axis(MainAxisAlignment::Center);
         assert_eq!(layout.main_axis_alignment, MainAxisAlignment::Center);
+    }
+
+    #[test]
+    fn with_cross_axis_sets_alignment() {
+        let layout = FrameLayout::default().with_cross_axis(CrossAxisAlignment::Stretch);
         assert_eq!(layout.cross_axis_alignment, CrossAxisAlignment::Stretch);
     }
 
-    #[test]
-    fn test_padding_helpers() {
-        let uniform = Padding::all(10.0);
-        assert_eq!(uniform.horizontal(), 20.0);
-        assert_eq!(uniform.vertical(), 20.0);
+    // === Padding helpers ===
 
-        let symmetric = Padding::symmetric(5.0, 15.0);
-        assert_eq!(symmetric.left, 5.0);
-        assert_eq!(symmetric.right, 5.0);
-        assert_eq!(symmetric.top, 15.0);
-        assert_eq!(symmetric.bottom, 15.0);
+    #[test]
+    fn padding_all_sets_uniform_value() {
+        let p = Padding::all(10.0);
+        assert_eq!(p.top, 10.0);
+        assert_eq!(p.right, 10.0);
+        assert_eq!(p.bottom, 10.0);
+        assert_eq!(p.left, 10.0);
     }
 
     #[test]
-    fn test_child_layout_defaults() {
-        let child = ChildLayout::default();
-        assert_eq!(child.width_mode, SizingMode::Fixed);
-        assert_eq!(child.height_mode, SizingMode::Fixed);
+    fn padding_horizontal_sums_left_and_right() {
+        let p = Padding { left: 5.0, right: 15.0, top: 0.0, bottom: 0.0 };
+        assert_eq!(p.horizontal(), 20.0);
+    }
+
+    #[test]
+    fn padding_vertical_sums_top_and_bottom() {
+        let p = Padding { left: 0.0, right: 0.0, top: 8.0, bottom: 12.0 };
+        assert_eq!(p.vertical(), 20.0);
+    }
+
+    #[test]
+    fn padding_symmetric_sets_horizontal_and_vertical() {
+        let p = Padding::symmetric(5.0, 15.0);
+        assert_eq!(p.left, 5.0);
+        assert_eq!(p.right, 5.0);
+        assert_eq!(p.top, 15.0);
+        assert_eq!(p.bottom, 15.0);
+    }
+
+    // === ChildLayout defaults ===
+
+    #[test]
+    fn child_layout_default_width_is_fixed() {
+        assert_eq!(ChildLayout::default().width_mode, SizingMode::Fixed);
+    }
+
+    #[test]
+    fn child_layout_default_height_is_fixed() {
+        assert_eq!(ChildLayout::default().height_mode, SizingMode::Fixed);
     }
 
     #[test]

--- a/crates/node_2/src/layout_engine.rs
+++ b/crates/node_2/src/layout_engine.rs
@@ -248,7 +248,16 @@ mod tests {
     use super::*;
     use crate::layout::Padding;
 
-    fn make_child(id: u128, width: f32, height: f32) -> LayoutInput {
+    // === Test Helpers ===
+    // These helpers create LayoutInput with explicit sizing modes.
+    // The naming convention makes the sizing mode clear:
+    // - fixed_child: both width and height are Fixed (won't stretch)
+    // - fill_width_child: width is Fill (stretches horizontally), height is Fixed
+    // - fill_height_child: width is Fixed, height is Fill (stretches vertically)
+
+    /// Create a child with Fixed sizing on both axes.
+    /// The child will maintain its specified size regardless of layout alignment.
+    fn fixed_child(id: u128, width: f32, height: f32) -> LayoutInput {
         LayoutInput {
             id: ShapeId::from_u128(id),
             size: CanvasSize::new(width, height),
@@ -257,7 +266,9 @@ mod tests {
         }
     }
 
-    fn make_fill_child(id: u128, width: f32, height: f32) -> LayoutInput {
+    /// Create a child that fills available width (stretches horizontally).
+    /// Height remains fixed at the specified value.
+    fn fill_width_child(id: u128, width: f32, height: f32) -> LayoutInput {
         LayoutInput {
             id: ShapeId::from_u128(id),
             size: CanvasSize::new(width, height),
@@ -266,10 +277,22 @@ mod tests {
         }
     }
 
+    /// Create a child that fills available height (stretches vertically).
+    /// Width remains fixed at the specified value.
+    #[allow(dead_code)]
+    fn fill_height_child(id: u128, width: f32, height: f32) -> LayoutInput {
+        LayoutInput {
+            id: ShapeId::from_u128(id),
+            size: CanvasSize::new(width, height),
+            width_mode: SizingMode::Fixed,
+            height_mode: SizingMode::Fill,
+        }
+    }
+
     #[test]
     fn test_row_layout_start() {
         let layout = FrameLayout::default();
-        let children = vec![make_child(1, 50.0, 30.0), make_child(2, 50.0, 30.0)];
+        let children = vec![fixed_child(1, 50.0, 30.0), fixed_child(2, 50.0, 30.0)];
 
         let result = compute_layout(CanvasSize::new(200.0, 100.0), &layout, &children);
 
@@ -281,7 +304,7 @@ mod tests {
     #[test]
     fn test_row_layout_with_gap() {
         let layout = FrameLayout::row().with_gap(10.0);
-        let children = vec![make_child(1, 50.0, 30.0), make_child(2, 50.0, 30.0)];
+        let children = vec![fixed_child(1, 50.0, 30.0), fixed_child(2, 50.0, 30.0)];
 
         let result = compute_layout(CanvasSize::new(200.0, 100.0), &layout, &children);
 
@@ -292,7 +315,7 @@ mod tests {
     #[test]
     fn test_row_layout_center() {
         let layout = FrameLayout::row().with_main_axis(MainAxisAlignment::Center);
-        let children = vec![make_child(1, 50.0, 30.0), make_child(2, 50.0, 30.0)];
+        let children = vec![fixed_child(1, 50.0, 30.0), fixed_child(2, 50.0, 30.0)];
 
         let result = compute_layout(CanvasSize::new(200.0, 100.0), &layout, &children);
 
@@ -304,7 +327,7 @@ mod tests {
     #[test]
     fn test_row_layout_end() {
         let layout = FrameLayout::row().with_main_axis(MainAxisAlignment::End);
-        let children = vec![make_child(1, 50.0, 30.0), make_child(2, 50.0, 30.0)];
+        let children = vec![fixed_child(1, 50.0, 30.0), fixed_child(2, 50.0, 30.0)];
 
         let result = compute_layout(CanvasSize::new(200.0, 100.0), &layout, &children);
 
@@ -317,9 +340,9 @@ mod tests {
     fn test_row_layout_space_between() {
         let layout = FrameLayout::row().with_main_axis(MainAxisAlignment::SpaceBetween);
         let children = vec![
-            make_child(1, 50.0, 30.0),
-            make_child(2, 50.0, 30.0),
-            make_child(3, 50.0, 30.0),
+            fixed_child(1, 50.0, 30.0),
+            fixed_child(2, 50.0, 30.0),
+            fixed_child(3, 50.0, 30.0),
         ];
 
         let result = compute_layout(CanvasSize::new(200.0, 100.0), &layout, &children);
@@ -333,7 +356,7 @@ mod tests {
     #[test]
     fn test_column_layout() {
         let layout = FrameLayout::column().with_gap(10.0);
-        let children = vec![make_child(1, 50.0, 30.0), make_child(2, 50.0, 40.0)];
+        let children = vec![fixed_child(1, 50.0, 30.0), fixed_child(2, 50.0, 40.0)];
 
         let result = compute_layout(CanvasSize::new(200.0, 200.0), &layout, &children);
 
@@ -344,7 +367,7 @@ mod tests {
     #[test]
     fn test_cross_axis_center() {
         let layout = FrameLayout::row().with_cross_axis(CrossAxisAlignment::Center);
-        let children = vec![make_child(1, 50.0, 30.0)];
+        let children = vec![fixed_child(1, 50.0, 30.0)];
 
         let result = compute_layout(CanvasSize::new(200.0, 100.0), &layout, &children);
 
@@ -355,7 +378,7 @@ mod tests {
     #[test]
     fn test_cross_axis_end() {
         let layout = FrameLayout::row().with_cross_axis(CrossAxisAlignment::End);
-        let children = vec![make_child(1, 50.0, 30.0)];
+        let children = vec![fixed_child(1, 50.0, 30.0)];
 
         let result = compute_layout(CanvasSize::new(200.0, 100.0), &layout, &children);
 
@@ -366,7 +389,7 @@ mod tests {
     #[test]
     fn test_cross_axis_stretch() {
         let layout = FrameLayout::row().with_cross_axis(CrossAxisAlignment::Stretch);
-        let children = vec![make_child(1, 50.0, 30.0)];
+        let children = vec![fixed_child(1, 50.0, 30.0)];
 
         let result = compute_layout(CanvasSize::new(200.0, 100.0), &layout, &children);
 
@@ -381,7 +404,7 @@ mod tests {
             padding: Padding::all(20.0),
             ..Default::default()
         };
-        let children = vec![make_child(1, 50.0, 30.0)];
+        let children = vec![fixed_child(1, 50.0, 30.0)];
 
         let result = compute_layout(CanvasSize::new(200.0, 100.0), &layout, &children);
 
@@ -393,9 +416,9 @@ mod tests {
     fn test_fill_children() {
         let layout = FrameLayout::row().with_gap(10.0);
         let children = vec![
-            make_child(1, 50.0, 30.0),       // Fixed 50
-            make_fill_child(2, 50.0, 30.0),  // Fill
-            make_child(3, 50.0, 30.0),       // Fixed 50
+            fixed_child(1, 50.0, 30.0),       // Fixed 50
+            fill_width_child(2, 50.0, 30.0),  // Fill
+            fixed_child(3, 50.0, 30.0),       // Fixed 50
         ];
 
         let result = compute_layout(CanvasSize::new(200.0, 100.0), &layout, &children);
@@ -415,8 +438,8 @@ mod tests {
     fn test_multiple_fill_children() {
         let layout = FrameLayout::row();
         let children = vec![
-            make_fill_child(1, 0.0, 30.0),
-            make_fill_child(2, 0.0, 30.0),
+            fill_width_child(1, 0.0, 30.0),
+            fill_width_child(2, 0.0, 30.0),
         ];
 
         let result = compute_layout(CanvasSize::new(200.0, 100.0), &layout, &children);
@@ -439,7 +462,7 @@ mod tests {
     #[test]
     fn test_single_child_space_between() {
         let layout = FrameLayout::row().with_main_axis(MainAxisAlignment::SpaceBetween);
-        let children = vec![make_child(1, 50.0, 30.0)];
+        let children = vec![fixed_child(1, 50.0, 30.0)];
 
         let result = compute_layout(CanvasSize::new(200.0, 100.0), &layout, &children);
 
@@ -452,8 +475,8 @@ mod tests {
         // When children are larger than frame, should not have negative positions
         let layout = FrameLayout::column().with_main_axis(MainAxisAlignment::SpaceBetween);
         let children = vec![
-            make_child(1, 50.0, 300.0),  // 300 tall
-            make_child(2, 50.0, 300.0),  // 300 tall - total 600, frame only 100
+            fixed_child(1, 50.0, 300.0),  // 300 tall
+            fixed_child(2, 50.0, 300.0),  // 300 tall - total 600, frame only 100
         ];
 
         let result = compute_layout(CanvasSize::new(100.0, 100.0), &layout, &children);
@@ -469,7 +492,7 @@ mod tests {
     fn test_overflow_center() {
         // When children are larger than frame, should clamp to 0
         let layout = FrameLayout::row().with_main_axis(MainAxisAlignment::Center);
-        let children = vec![make_child(1, 300.0, 30.0)]; // 300 wide, frame only 100
+        let children = vec![fixed_child(1, 300.0, 30.0)]; // 300 wide, frame only 100
 
         let result = compute_layout(CanvasSize::new(100.0, 100.0), &layout, &children);
 
@@ -481,7 +504,7 @@ mod tests {
     fn test_overflow_end() {
         // When children are larger than frame, should clamp to 0
         let layout = FrameLayout::row().with_main_axis(MainAxisAlignment::End);
-        let children = vec![make_child(1, 300.0, 30.0)]; // 300 wide, frame only 100
+        let children = vec![fixed_child(1, 300.0, 30.0)]; // 300 wide, frame only 100
 
         let result = compute_layout(CanvasSize::new(100.0, 100.0), &layout, &children);
 


### PR DESCRIPTION
## Summary

Improves test quality across multiple crates following TDD methodology:

- Split multi-assertion tests into single-behavior tests
- Replace print-only tests with structural assertions
- Add missing tests for new computed value methods
- Rename test helpers to make defaults explicit

## Changes by Commit

| Commit | Package | Change |
|--------|---------|--------|
| Split bounds tests | common | 22 → 29 tests |
| Fix serialization tests | api | 3 → 10 tests |
| Split builder tests | node_2 | 5 → 18 tests |
| Add computed value tests | node_2 | 2 → 19 tests |
| Rename helpers | node_2 | Clearer naming |

## Test plan

- [x] All existing tests pass
- [x] New tests verify previously untested behavior
- [x] `cargo test --workspace` passes