### PR TITLE
Fix: child node resize handles use world positions

### DIFF
--- a/crates/canvas/src/canvas.rs
+++ b/crates/canvas/src/canvas.rs
@@ -735,7 +735,10 @@ impl Canvas {
         self.selection.iter().any(|id| self.is_in_autolayout(*id))
     }
 
-    /// Get the bounding box of selected shapes in canvas coordinates.
+    /// Get the bounding box of selected shapes in world (canvas) coordinates.
+    ///
+    /// Uses world positions so that child shapes inside frames are correctly
+    /// positioned in absolute canvas space.
     pub fn selection_bounds(&self) -> Option<(CanvasPoint, CanvasPoint)> {
         let selected: Vec<_> = self
             .shapes
@@ -751,9 +754,15 @@ impl Canvas {
         let mut max = Vec2::new(f32::MIN, f32::MIN);
 
         for shape in selected {
-            let (shape_min, shape_max) = shape.bounds();
-            min = min.min(shape_min.0);
-            max = max.max(shape_max.0);
+            // Use world position for correct bounds of child shapes
+            let world_pos = self
+                .world_position_cache
+                .get(&shape.id)
+                .copied()
+                .unwrap_or_else(|| shape.world_position(&self.shapes));
+            let world_max = CanvasPoint(world_pos.0 + shape.effective_size().0);
+            min = min.min(world_pos.0);
+            max = max.max(world_max.0);
         }
 
         Some((CanvasPoint(min), CanvasPoint(max)))

--- a/crates/canvas/src/element.rs
+++ b/crates/canvas/src/element.rs
@@ -115,7 +115,7 @@ impl Element for CanvasElement {
             // Paint multi-selection bounding box
             if selection.len() > 1 {
                 if let Some((min, max)) =
-                    selection_bounds_from_shapes(&shapes, &selection, &viewport)
+                    selection_bounds_from_shapes(&shapes, &selection, &viewport, &world_positions)
                 {
                     let screen_bounds = Bounds {
                         origin: point(bounds.origin.x + px(min.x), bounds.origin.y + px(min.y)),
@@ -253,6 +253,7 @@ fn selection_bounds_from_shapes(
     shapes: &[node::Shape],
     selection: &std::collections::HashSet<node::ShapeId>,
     viewport: &crate::Viewport,
+    world_positions: &std::collections::HashMap<node::ShapeId, node::CanvasPoint>,
 ) -> Option<(Vec2, Vec2)> {
     let selected: Vec<_> = shapes.iter().filter(|s| selection.contains(&s.id)).collect();
 
@@ -264,8 +265,13 @@ fn selection_bounds_from_shapes(
     let mut max = Vec2::new(f32::MIN, f32::MIN);
 
     for shape in selected {
-        let canvas_max = CanvasPoint(shape.position.0 + shape.size.0);
-        let screen_min = viewport.canvas_to_screen(shape.position);
+        // Use world position for correct bounds of child shapes
+        let world_pos = world_positions
+            .get(&shape.id)
+            .copied()
+            .unwrap_or_else(|| shape.world_position(shapes));
+        let canvas_max = CanvasPoint(world_pos.0 + shape.effective_size().0);
+        let screen_min = viewport.canvas_to_screen(world_pos);
         let screen_max = viewport.canvas_to_screen(canvas_max);
         min.x = min.x.min(screen_min.x());
         min.y = min.y.min(screen_min.y());


### PR DESCRIPTION
## Summary
- Fixed resize handles for child nodes inside frames not working correctly
- Selection bounds now use world positions instead of local/relative positions
- This ensures resize handles are positioned correctly in absolute canvas coordinates

## Problem
Clicks on resize handles for child nodes inside frames would:
1. Fall through to the parent element, or
2. Deselect the element if handles were outside the parent's bounds

This was caused by `selection_bounds()` and `selection_bounds_from_shapes()` using local positions (relative to parent) instead of world positions (absolute canvas coordinates).

## Solution
Both functions now use `world_position()` (via the cache when available) to calculate selection bounds in world coordinates, matching how shapes are actually rendered.

## Test plan
- [ ] Create a frame and add a child rectangle inside it
- [ ] Select the child rectangle
- [ ] Verify resize handles appear at the correct position
- [ ] Click and drag resize handles to resize the child
- [ ] Verify the child resizes correctly without selecting/deselecting unexpectedly

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)