### PR TITLE
fix: use world coordinates consistently in resize operations

### DIFF
--- a/crates/canvas/src/canvas.rs
+++ b/crates/canvas/src/canvas.rs
@@ -588,11 +588,19 @@ impl Canvas {
         };
 
         let shape_ids: Vec<_> = self.selection.iter().copied().collect();
+        // Capture world positions and effective sizes for consistency with selection_bounds
         let start_shape_data: Vec<_> = self
             .shapes
             .iter()
             .filter(|s| self.selection.contains(&s.id))
-            .map(|s| (s.id, s.position, s.size))
+            .map(|s| {
+                let world_pos = self
+                    .world_position_cache
+                    .get(&s.id)
+                    .copied()
+                    .unwrap_or_else(|| s.world_position(&self.shapes));
+                (s.id, world_pos, s.effective_size())
+            })
             .collect();
 
         self.drag = Some(DragState::ResizingShapes {
@@ -658,10 +666,20 @@ impl Canvas {
         );
 
         // Update each shape proportionally
-        for (id, orig_pos, orig_size) in start_shape_data {
+        for (id, orig_world_pos, orig_size) in start_shape_data {
+            // Get parent info before mutable borrow
+            let parent_world_pos = self.shapes.iter()
+                .find(|s| s.id == id)
+                .and_then(|s| s.parent)
+                .and_then(|parent_id| {
+                    self.world_position_cache
+                        .get(&parent_id)
+                        .copied()
+                });
+
             if let Some(shape) = self.get_shape_mut(id) {
-                // Extract raw values
-                let orig_pos = orig_pos.0;
+                // Extract raw values (orig_world_pos is now in world coordinates)
+                let orig_pos = orig_world_pos.0;
                 let orig_size = orig_size.0;
 
                 // Calculate relative position within original bounds (0 to 1)
@@ -673,9 +691,18 @@ impl Canvas {
                     if flip_y { start_size.y - rel_pos.y - orig_size.y } else { rel_pos.y },
                 );
 
-                // Scale position and size
-                shape.position = CanvasPoint(new_min + rel_pos * scale);
-                shape.size = CanvasSize(orig_size * scale);
+                // Calculate new world position and size
+                let new_world_pos = new_min + rel_pos * scale;
+                let new_size = orig_size * scale;
+
+                // Convert world position back to local if shape has a parent
+                let new_local_pos = match parent_world_pos {
+                    Some(parent_pos) => new_world_pos - parent_pos.0,
+                    None => new_world_pos, // Root shape, world = local
+                };
+
+                shape.position = CanvasPoint(new_local_pos);
+                shape.size = CanvasSize(new_size);
             }
         }
         cx.notify();
@@ -735,7 +762,10 @@ impl Canvas {
         self.selection.iter().any(|id| self.is_in_autolayout(*id))
     }
 
-    /// Get the bounding box of selected shapes in canvas coordinates.
+    /// Get the bounding box of selected shapes in world (canvas) coordinates.
+    ///
+    /// Uses world positions so that child shapes inside frames are correctly
+    /// positioned in absolute canvas space.
     pub fn selection_bounds(&self) -> Option<(CanvasPoint, CanvasPoint)> {
         let selected: Vec<_> = self
             .shapes
@@ -751,9 +781,15 @@ impl Canvas {
         let mut max = Vec2::new(f32::MIN, f32::MIN);
 
         for shape in selected {
-            let (shape_min, shape_max) = shape.bounds();
-            min = min.min(shape_min.0);
-            max = max.max(shape_max.0);
+            // Use world position for correct bounds of child shapes
+            let world_pos = self
+                .world_position_cache
+                .get(&shape.id)
+                .copied()
+                .unwrap_or_else(|| shape.world_position(&self.shapes));
+            let world_max = CanvasPoint(world_pos.0 + shape.effective_size().0);
+            min = min.min(world_pos.0);
+            max = max.max(world_max.0);
         }
 
         Some((CanvasPoint(min), CanvasPoint(max)))

--- a/crates/canvas/src/element.rs
+++ b/crates/canvas/src/element.rs
@@ -115,7 +115,7 @@ impl Element for CanvasElement {
             // Paint multi-selection bounding box
             if selection.len() > 1 {
                 if let Some((min, max)) =
-                    selection_bounds_from_shapes(&shapes, &selection, &viewport)
+                    selection_bounds_from_shapes(&shapes, &selection, &viewport, &world_positions)
                 {
                     let screen_bounds = Bounds {
                         origin: point(bounds.origin.x + px(min.x), bounds.origin.y + px(min.y)),
@@ -253,6 +253,7 @@ fn selection_bounds_from_shapes(
     shapes: &[node::Shape],
     selection: &std::collections::HashSet<node::ShapeId>,
     viewport: &crate::Viewport,
+    world_positions: &std::collections::HashMap<node::ShapeId, node::CanvasPoint>,
 ) -> Option<(Vec2, Vec2)> {
     let selected: Vec<_> = shapes.iter().filter(|s| selection.contains(&s.id)).collect();
 
@@ -264,8 +265,13 @@ fn selection_bounds_from_shapes(
     let mut max = Vec2::new(f32::MIN, f32::MIN);
 
     for shape in selected {
-        let canvas_max = CanvasPoint(shape.position.0 + shape.size.0);
-        let screen_min = viewport.canvas_to_screen(shape.position);
+        // Use world position for correct bounds of child shapes
+        let world_pos = world_positions
+            .get(&shape.id)
+            .copied()
+            .unwrap_or_else(|| shape.world_position(shapes));
+        let canvas_max = CanvasPoint(world_pos.0 + shape.effective_size().0);
+        let screen_min = viewport.canvas_to_screen(world_pos);
         let screen_max = viewport.canvas_to_screen(canvas_max);
         min.x = min.x.min(screen_min.x());
         min.y = min.y.min(screen_min.y());
@@ -487,8 +493,11 @@ fn paint_shape_recursive(
         .copied()
         .unwrap_or_else(|| shape.world_position(all_shapes));
 
+    // Use effective_size for consistent rendering with selection bounds
+    let effective_size = shape.effective_size();
+
     // Convert to screen coordinates
-    let screen_rect = viewport.canvas_to_screen_bounds(world_pos, shape.size);
+    let screen_rect = viewport.canvas_to_screen_bounds(world_pos, effective_size);
     let screen_bounds = Bounds {
         origin: point(
             canvas_bounds.origin.x + px(screen_rect.origin.x),
@@ -503,7 +512,7 @@ fn paint_shape_recursive(
     }
 
     // Clamp corner radius to half the smaller dimension
-    let max_radius = shape.size.width().min(shape.size.height()) / 2.0;
+    let max_radius = effective_size.width().min(effective_size.height()) / 2.0;
     let corner_radius = px(shape.corner_radius.min(max_radius) * viewport.zoom);
 
     // Paint fill


### PR DESCRIPTION
## Summary

- Fixes coordinate space mismatch in resize operations that caused:
  - Resize handles to be positioned incorrectly for child shapes inside frames
  - Resize behavior to not accurately match cursor movement
- Uses world (absolute) coordinates consistently throughout resize flow
- Properly converts back to local coordinates when updating child shape positions

## Changes

1. **`selection_bounds()`** - Now uses world positions from cache for correct bounds calculation of child shapes
2. **`start_resize()`** - Captures world positions and effective sizes instead of local/raw values
3. **`update_resize()`** - Converts calculated world positions back to local coordinates for child shapes
4. **`selection_bounds_from_shapes()`** - Uses world positions for painting multi-selection bounds
5. **`paint_shape_recursive()`** - Uses `effective_size()` for consistent rendering with selection bounds

## Root Cause Analysis

The issue was caused by a coordinate space mismatch:
- `selection_bounds()` was using local positions (relative to parent) instead of world positions
- `start_shape_data` captured local positions but the resize delta was calculated in world coordinates
- This caused the resize handle hit areas and visual positions to be misaligned for child shapes
- For child shapes, the resize movement appeared "faster" or incorrectly positioned

## Test plan

- [ ] Create a root shape and verify resize handles work correctly (1:1 cursor tracking)
- [ ] Create a frame with child shapes and verify child resize handles are positioned correctly
- [ ] Verify child shape resize tracks cursor movement accurately
- [ ] Test with zoom levels other than 1.0
- [ ] Test multi-selection resize with mixed root and child shapes

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)