### PR TITLE
fix: use system UI font for text rendering

### DIFF
--- a/crates/luna/src/luna.rs
+++ b/crates/luna/src/luna.rs
@@ -327,7 +327,7 @@ impl Render for Luna {
             .size_full()
             .flex()
             .flex_row()
-            .font_family("Berkeley Mono")
+            .font_family(".SystemUIFont")
             .text_xs()
             .bg(self.theme.ui_background)
             .text_color(self.theme.ui_text)


### PR DESCRIPTION
## Summary

- Fixed text not rendering after the GPUI update (#32)
- Changed font from "Berkeley Mono" (custom font not available) to ".SystemUIFont" (GPUI virtual font that maps to platform defaults)

## Root Cause

The GPUI update from crates.io v0.2.2 to the git version changed how fonts are handled. "Berkeley Mono" is a custom font that:
1. Isn't installed on most systems
2. Isn't embedded in the application assets

The new GPUI has a font fallback chain, but it requires either embedded fonts or available system fonts.

## Solution

Changed to `.SystemUIFont`, which is a special GPUI virtual font name that maps to:
- Helvetica on macOS
- Segoe UI on Windows  
- System fonts on Linux (Ubuntu, Noto Sans, DejaVu Sans, etc.)

## Test plan

- [ ] Run the application and verify text is visible in:
  - Layer list panel
  - Properties panel  
  - Tool tooltips
  - Menu items

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)